### PR TITLE
Separate PyPI publishing from package CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         python-version: ["3.10"]
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -37,7 +36,3 @@ jobs:
 
       - name: Show package version
         run: grep -r "version" pyproject.toml || grep -r "__version__" rtichoke/ || python -c "import rtichoke; print(rtichoke.__version__)"
-
-      - name: Publish package
-        if: github.ref == 'refs/heads/main' && matrix.python-version == '3.10'
-        run: uv publish


### PR DESCRIPTION
## What changed

- remove `uv publish` from the ordinary package CI workflow
- remove the no-longer-needed OIDC write permission
- retain package installation, build, tests, and version reporting on PRs and pushes to `main`

## Why

The Great Docs merge correctly kept package version `0.1.28`, but ordinary CI attempted to republish that immutable PyPI version and failed with HTTP 400 because the wheel already exists.

Publishing should be handled by an intentional release/tag workflow rather than every push to `main`. Adding or redesigning that release automation is deliberately outside this focused fix.

## Validation

The previous failed run completed installation, package build, and all 10 tests successfully; only the PyPI re-upload failed.
