### PR TITLE
Prevent merged PR cleanup from cancelling docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: documentation-deployments
+  cancel-in-progress: false
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## What changed

- use one shared concurrency group for documentation writes
- queue documentation deployments instead of cancelling an in-progress deployment

## Why

When a PR is merged, GitHub emits both:

1. a push to `main`, which builds and publishes production docs
2. a closed pull-request event, which removes the PR preview

For a merged PR, both runs resolve to the same previous concurrency key. Because `cancel-in-progress` was enabled, the preview-cleanup run cancelled the production deployment. This happened after both PR #282 and PR #283.

Serializing the runs prevents concurrent writes to `gh-pages` and ensures neither production publishing nor preview cleanup is dropped.

## Validation

- package CI after PR #283 passed
- the cancelled production run and successful closed-event cleanup started at the same timestamp
- this change is limited to the documentation workflow concurrency policy
