### PR TITLE
Polish Great Docs onboarding and API conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@
 
 The library is designed to be easy to use while still offering a high degree of control over the final plots.
 
+For some reproducible examples please visit [rtichoke blog](https://rtichoke-blog.netlify.app/)!
+
 ## Installation
 
-Install `rtichoke` from PyPI:
+For a project managed with [uv](https://docs.astral.sh/uv/), add `rtichoke` with:
+
+```bash
+uv add rtichoke
+```
+
+Alternatively, install `rtichoke` from PyPI with pip:
 
 ```bash
 pip install rtichoke

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -5,6 +5,30 @@ user_guide: user_guide
 homepage: user_guide
 site_url: https://uriahf.github.io/rtichoke_python/
 
+include_in_header:
+  - text: |
+      <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const nav = document.querySelector('nav.navbar ul.navbar-nav.me-auto');
+        if (!nav || nav.querySelector('[data-rtichoke-blog-link]')) return;
+
+        const item = document.createElement('li');
+        item.className = 'nav-item';
+        item.setAttribute('data-rtichoke-blog-link', '');
+
+        const link = document.createElement('a');
+        link.className = 'nav-link';
+        link.href = 'https://rtichoke-blog.netlify.app/';
+        link.textContent = 'Blog ↗';
+
+        item.appendChild(link);
+        const reference = [...nav.children].find((el) =>
+          el.textContent.trim().toLowerCase().includes('reference')
+        );
+        nav.insertBefore(item, reference || null);
+      });
+      </script>
+
 site:
   css: site.css
 

--- a/user_guide/00-getting-started.qmd
+++ b/user_guide/00-getting-started.qmd
@@ -99,4 +99,4 @@ fig = rk.create_calibration_curve(
 fig.show()
 ```
 
-From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](01-naming-conventions.qmd) guide explains how the exported function families fit together.
+From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](user-guide/naming-conventions.html) guide explains how the exported function families fit together.

--- a/user_guide/00-getting-started.qmd
+++ b/user_guide/00-getting-started.qmd
@@ -5,9 +5,19 @@ guide-section: "Getting Started"
 
 `rtichoke` is a Python library for interactive visualization of predictive-model performance. It supports discrimination, calibration, utility, and time-to-event evaluation workflows.
 
+For some reproducible examples please visit [rtichoke blog](https://rtichoke-blog.netlify.app/)!
+
 ## Installation
 
-Install `rtichoke` from PyPI:
+If you use [uv](https://docs.astral.sh/uv/) to manage your Python project, add `rtichoke` with:
+
+```bash
+uv add rtichoke
+```
+
+This adds `rtichoke` to your project dependencies and updates the uv lockfile.
+
+If you are not using uv, install `rtichoke` from PyPI with pip:
 
 ```bash
 pip install rtichoke
@@ -89,4 +99,4 @@ fig = rk.create_calibration_curve(
 fig.show()
 ```
 
-From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants.
+From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](01-naming-conventions.qmd) guide explains how the exported function families fit together.

--- a/user_guide/01-naming-conventions.qmd
+++ b/user_guide/01-naming-conventions.qmd
@@ -1,0 +1,56 @@
+---
+title: "Naming Conventions"
+guide-section: "Getting Started"
+---
+
+`rtichoke` uses consistent function names so that the API becomes easier to predict once you know the main families.
+
+## Function families
+
+| Prefix | Purpose | Typical input | Typical output |
+|---|---|---|---|
+| `prepare_*` | Prepare reusable performance data | predictions and observed outcomes | performance data |
+| `create_*` | Prepare data and create a visualization in one call | predictions and observed outcomes | interactive figure |
+| `plot_*` | Visualize data that has already been prepared | performance data | interactive figure |
+
+For example, a direct ROC workflow uses `create_roc_curve()`, while a workflow that first prepares reusable performance data can pass those results to `plot_roc_curve()`.
+
+## Curve families
+
+The same naming pattern repeats across the main performance views:
+
+| Performance view | Direct visualization | Plot prepared data |
+|---|---|---|
+| ROC | `create_roc_curve()` | `plot_roc_curve()` |
+| Precision–Recall | `create_precision_recall_curve()` | `plot_precision_recall_curve()` |
+| Gains | `create_gains_curve()` | `plot_gains_curve()` |
+| Lift | `create_lift_curve()` | `plot_lift_curve()` |
+| Decision curve | `create_decision_curve()` | `plot_decision_curve()` |
+
+Calibration currently uses the direct `create_calibration_curve()` interface.
+
+## Time-to-event variants
+
+Functions ending in `_times` extend the corresponding workflow to time-to-event outcomes. For example:
+
+- `create_roc_curve()` → binary-outcome ROC curve
+- `create_roc_curve_times()` → time-to-event ROC curve
+- `create_calibration_curve()` → binary-outcome calibration curve
+- `create_calibration_curve_times()` → time-to-event calibration curve
+- `create_decision_curve()` → binary-outcome decision curve
+- `create_decision_curve_times()` → time-to-event decision curve
+
+The same convention is used for the performance-data preparation functions, such as `prepare_performance_data()` and `prepare_performance_data_times()`.
+
+## A useful mental model
+
+Think of the API as a small grammar:
+
+```text
+prepare + performance data        -> reusable data
+create  + metric/curve            -> data to figure
+plot    + metric/curve            -> prepared data to figure
+*_times                           -> time-to-event version
+```
+
+This convention is intended to make related functions discoverable without requiring users to memorize every exported name.


### PR DESCRIPTION
## What changed

- adds the same rtichoke-blog reproducible-examples link used by the R package
- makes `uv add rtichoke` the recommended project-managed installation path, with pip retained as an alternative
- adds a concise Naming Conventions guide covering `prepare_*`, `create_*`, `plot_*`, and `_times`
- adds a lightweight `Blog ↗` link to the Great Docs navbar pointing to the main rtichoke blog

## Why

This keeps the existing site architecture intact while making the Python documentation easier to navigate and more consistent with the R package documentation.

## Validation

The repository's existing documentation workflow should build Great Docs and publish a PR-specific rendered preview under `pr-preview/`. Please review the rendered navbar, Getting Started page, and Naming Conventions page before merging.

## Scope

No blog content is embedded into Great Docs and no Great Docs page shell is replaced or restyled by JavaScript.