### PR TITLE
Sort performance data deterministically

### DIFF
--- a/src/rtichoke/performance_data/performance_data.py
+++ b/src/rtichoke/performance_data/performance_data.py
@@ -158,4 +158,6 @@ def prepare_performance_data(
 
     performance_data = _turn_cumulative_aj_to_performance_data(cumulative_aj_data)
 
-    return performance_data
+    return performance_data.sort(
+        ["reference_group", "stratified_by", "chosen_cutoff"]
+    )


### PR DESCRIPTION
## What changed
- Sort `prepare_performance_data()` output by `reference_group`, `stratified_by`, and `chosen_cutoff`.
- This makes cutoff ordering deterministic instead of depending on Polars `group_by`/`pivot` output order.

## Why
The R implementation constructs probability thresholds in ascending order, so its public performance data is naturally ordered. The Python implementation aggregates with Polars and previously returned the resulting incidental row order. This change restores predictable R/Python parity for consumers inspecting or using the performance table.

## Scope
This intentionally changes only the public return ordering; metric calculations are untouched.