### PR TITLE
Document curve API constraints and troubleshooting

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -67,7 +67,7 @@ reference:
       - plot_lift_curve
 
   - title: Calibration
-    desc: Calibration visualizations for classification and time-to-event models. See the Curve API Compatibility guide for current multi-population and time-heuristic constraints.
+    desc: Calibration visualizations for classification and time-to-event models. See Curve API Compatibility for time-dependent heuristic and horizon differences.
     contents:
       - create_calibration_curve
       - create_calibration_curve_times

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -5,6 +5,10 @@ user_guide: user_guide
 homepage: user_guide
 site_url: https://uriahf.github.io/rtichoke_python/
 
+changelog:
+  enabled: true
+  max_releases: 50
+
 include_in_header:
   - text: |
       <script>
@@ -63,7 +67,7 @@ reference:
       - plot_lift_curve
 
   - title: Calibration
-    desc: Calibration visualizations for classification and time-to-event models.
+    desc: Calibration visualizations for classification and time-to-event models. See the Curve API Compatibility guide for current multi-population and time-heuristic constraints.
     contents:
       - create_calibration_curve
       - create_calibration_curve_times

--- a/skills/rtichoke/SKILL.md
+++ b/skills/rtichoke/SKILL.md
@@ -22,7 +22,7 @@ Similar names do not guarantee identical edge-case behavior.
 
 ## Calibration gotchas
 
-1. Calibration currently has stricter dict/dict population alignment than ROC, precision-recall, and decision curves. Differently sized named populations can raise a prediction-length versus population-size mismatch. Do not silently generalize sibling behavior to calibration.
+1. Matching `probs` / `reals` dictionary keys are paired population-by-population. Different populations may have different sample sizes; lengths only need to match within each population.
 2. `create_calibration_curve_times()` currently requires `heuristics_sets`; it does not inherit the default used by ROC/PR/decision `_times` functions.
 3. Do not blindly pass `censoring_heuristic="adjusted"` to time-dependent calibration. The current path can skip all horizons and finish with `No data remaining after applying heuristics and time horizons.` The documented working exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
 4. Prefer floating-point `fixed_time_horizons`, for example `[3.0, 6.0, 9.0]`. Integer horizons can currently leak a Polars `i64` versus `f64` join-key error.
@@ -31,12 +31,10 @@ Similar names do not guarantee identical edge-case behavior.
 
 When a call that works for ROC/PR/decision fails for calibration, first check whether the failure concerns:
 
-- unequal named population sizes,
+- mismatched population keys or within-population lengths,
 - `heuristics_sets`,
 - the censoring heuristic,
 - or integer time horizons.
-
-Treat these as documented current constraints. Do not work around validation with an undocumented `strict=False`-style assumption or change statistical semantics without first checking the implementation and tests.
 
 ## Resources
 

--- a/skills/rtichoke/SKILL.md
+++ b/skills/rtichoke/SKILL.md
@@ -6,7 +6,7 @@ Use this skill when writing or debugging Python code that evaluates predictive-m
 
 - Use the generated API reference for signatures and parameter details.
 - Use `llms-full.txt` for the complete API plus user-guide content.
-- Read **Curve API Compatibility** before assuming that ROC, precision-recall, decision, and calibration functions accept identical inputs.
+- Read **Curve API Compatibility** before assuming that all curve families accept identical time-dependent heuristics.
 - Search **Common Errors & Fixes** by literal exception text before source-diving.
 
 ## Function families
@@ -15,26 +15,32 @@ The main exported families include:
 
 - ROC: `create_roc_curve()`, `create_roc_curve_times()`
 - Precision-recall: `create_precision_recall_curve()`, `create_precision_recall_curve_times()`
+- Gains: `create_gains_curve()`, `create_gains_curve_times()`
+- Lift: `create_lift_curve()`, `create_lift_curve_times()`
 - Calibration: `create_calibration_curve()`, `create_calibration_curve_times()`
 - Decision curve: `create_decision_curve()`, `create_decision_curve_times()`
 
 Similar names do not guarantee identical edge-case behavior.
 
+## Shared input patterns
+
+- Named populations such as Train and Test can be represented by dictionaries. With dictionary-valued outcomes, keys are paired population-by-population and lengths must match within each population; populations themselves may have different sample sizes.
+- For time-dependent calls, dictionary-valued `times` follows the same population alignment.
+- A censoring heuristic affects estimates only when censored observations are present. A competing-event heuristic affects estimates only when competing events are present. Function-specific validation rules still apply independently of whether a heuristic would change the estimates.
+- `fixed_time_horizons` accepts numeric values. Integer horizons such as `[3, 6, 9]` are normalized to floats at the shared time-dependent processing boundary.
+
 ## Calibration gotchas
 
-1. Matching `probs` / `reals` dictionary keys are paired population-by-population. Different populations may have different sample sizes; lengths only need to match within each population.
-2. `create_calibration_curve_times()` currently requires `heuristics_sets`; it does not inherit the default used by ROC/PR/decision `_times` functions.
-3. Time-dependent calibration rejects `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"` with an actionable `Unsupported calibration heuristics` error. A supported exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
-4. `fixed_time_horizons` accepts numeric values. Integer horizons such as `[3, 6, 9]` are normalized to floats at the shared time-dependent processing boundary.
+1. `create_calibration_curve_times()` currently requires `heuristics_sets`; it does not inherit the default used by ROC/PR/Gains/Lift/decision `_times` functions.
+2. Time-dependent calibration rejects `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"` with an actionable `Unsupported calibration heuristics` error. A supported exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
 
 ## Debugging rule
 
-When a call that works for ROC/PR/decision fails for calibration, first check whether the failure concerns:
+When a call that works for another time-dependent curve family fails for calibration, first check whether the failure concerns:
 
 - mismatched population keys or within-population lengths,
 - `heuristics_sets`,
-- the censoring heuristic,
-- or unsupported calibration heuristics.
+- or an unsupported calibration heuristic.
 
 ## Resources
 

--- a/skills/rtichoke/SKILL.md
+++ b/skills/rtichoke/SKILL.md
@@ -1,0 +1,45 @@
+# rtichoke
+
+Use this skill when writing or debugging Python code that evaluates predictive-model performance with `rtichoke`.
+
+## Start here
+
+- Use the generated API reference for signatures and parameter details.
+- Use `llms-full.txt` for the complete API plus user-guide content.
+- Read **Curve API Compatibility** before assuming that ROC, precision-recall, decision, and calibration functions accept identical inputs.
+- Search **Common Errors & Fixes** by literal exception text before source-diving.
+
+## Function families
+
+The main exported families include:
+
+- ROC: `create_roc_curve()`, `create_roc_curve_times()`
+- Precision-recall: `create_precision_recall_curve()`, `create_precision_recall_curve_times()`
+- Calibration: `create_calibration_curve()`, `create_calibration_curve_times()`
+- Decision curve: `create_decision_curve()`, `create_decision_curve_times()`
+
+Similar names do not guarantee identical edge-case behavior.
+
+## Calibration gotchas
+
+1. Calibration currently has stricter dict/dict population alignment than ROC, precision-recall, and decision curves. Differently sized named populations can raise a prediction-length versus population-size mismatch. Do not silently generalize sibling behavior to calibration.
+2. `create_calibration_curve_times()` currently requires `heuristics_sets`; it does not inherit the default used by ROC/PR/decision `_times` functions.
+3. Do not blindly pass `censoring_heuristic="adjusted"` to time-dependent calibration. The current path can skip all horizons and finish with `No data remaining after applying heuristics and time horizons.` The documented working exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
+4. Prefer floating-point `fixed_time_horizons`, for example `[3.0, 6.0, 9.0]`. Integer horizons can currently leak a Polars `i64` versus `f64` join-key error.
+
+## Debugging rule
+
+When a call that works for ROC/PR/decision fails for calibration, first check whether the failure concerns:
+
+- unequal named population sizes,
+- `heuristics_sets`,
+- the censoring heuristic,
+- or integer time horizons.
+
+Treat these as documented current constraints. Do not work around validation with an undocumented `strict=False`-style assumption or change statistical semantics without first checking the implementation and tests.
+
+## Resources
+
+- Documentation site: https://uriahf.github.io/rtichoke_python/
+- Full machine-readable documentation: https://uriahf.github.io/rtichoke_python/llms-full.txt
+- Source repository: https://github.com/uriahf/rtichoke_python

--- a/skills/rtichoke/SKILL.md
+++ b/skills/rtichoke/SKILL.md
@@ -24,8 +24,8 @@ Similar names do not guarantee identical edge-case behavior.
 
 1. Matching `probs` / `reals` dictionary keys are paired population-by-population. Different populations may have different sample sizes; lengths only need to match within each population.
 2. `create_calibration_curve_times()` currently requires `heuristics_sets`; it does not inherit the default used by ROC/PR/decision `_times` functions.
-3. Do not blindly pass `censoring_heuristic="adjusted"` to time-dependent calibration. The current path can skip all horizons and finish with `No data remaining after applying heuristics and time horizons.` The documented working exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
-4. Prefer floating-point `fixed_time_horizons`, for example `[3.0, 6.0, 9.0]`. Integer horizons can currently leak a Polars `i64` versus `f64` join-key error.
+3. Time-dependent calibration rejects `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"` with an actionable `Unsupported calibration heuristics` error. A supported exclusion-based path uses `censoring_heuristic="excluded"` with `competing_heuristic="adjusted_as_negative"`.
+4. `fixed_time_horizons` accepts numeric values. Integer horizons such as `[3, 6, 9]` are normalized to floats at the shared time-dependent processing boundary.
 
 ## Debugging rule
 
@@ -34,7 +34,7 @@ When a call that works for ROC/PR/decision fails for calibration, first check wh
 - mismatched population keys or within-population lengths,
 - `heuristics_sets`,
 - the censoring heuristic,
-- or integer time horizons.
+- or unsupported calibration heuristics.
 
 ## Resources
 

--- a/user_guide/00-getting-started.qmd
+++ b/user_guide/00-getting-started.qmd
@@ -37,6 +37,10 @@ Most `rtichoke` plotting functions use two dictionaries:
 - `probs`: model predictions, keyed by model or population name.
 - `reals`: observed outcomes, keyed by population name.
 
+::: {.callout-tip}
+Similar curve families do not have identical edge-case behavior. Before combining differently sized populations or moving code between ROC/PR/decision and calibration, see [Curve API Compatibility](curve-api-compatibility.html). If a call fails, [Common Errors & Fixes](common-errors.html) is searchable by literal exception text.
+:::
+
 ## Single model
 
 ```python
@@ -99,4 +103,8 @@ fig = rk.create_calibration_curve(
 fig.show()
 ```
 
-From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](user-guide/naming-conventions.html) guide explains how the exported function families fit together.
+::: {.callout-warning}
+The calibration example above deliberately uses equally sized Train and Test populations. The current calibration implementation can reject differently sized populations even when the analogous ROC, precision-recall, or decision-curve call works. See [Curve API Compatibility](curve-api-compatibility.html) for the documented constraint and an intentional failure example.
+:::
+
+From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](naming-conventions.html) guide explains how the exported function families fit together, while [Curve API Compatibility](curve-api-compatibility.html) documents where those families intentionally or currently differ.

--- a/user_guide/00-getting-started.qmd
+++ b/user_guide/00-getting-started.qmd
@@ -38,7 +38,7 @@ Most `rtichoke` plotting functions use two dictionaries:
 - `reals`: observed outcomes, keyed by population name.
 
 ::: {.callout-tip}
-Similar curve families do not have identical edge-case behavior. Before combining differently sized populations or moving code between ROC/PR/decision and calibration, see [Curve API Compatibility](curve-api-compatibility.html). If a call fails, [Common Errors & Fixes](common-errors.html) is searchable by literal exception text.
+Similar curve families can still differ in defaults and time-dependent handling. See [Curve API Compatibility](curve-api-compatibility.html), and if a call fails, search [Common Errors & Fixes](common-errors.html) by literal exception text.
 :::
 
 ## Single model
@@ -83,16 +83,16 @@ fig.show()
 
 ## Compare populations
 
-To compare a model across populations, provide matching keys in `probs` and `reals`.
+To compare a model across populations, provide matching keys in `probs` and `reals`. Population sizes may differ; each probability vector only needs to match the outcome vector for the same key.
 
 ```python
 probs_populations = {
     "Train": np.array([0.1, 0.9, 0.2, 0.8, 0.3, 0.7]),
-    "Test": np.array([0.2, 0.8, 0.3, 0.7, 0.4, 0.6]),
+    "Test": np.array([0.2, 0.8, 0.3, 0.7]),
 }
 reals_populations = {
     "Train": np.array([0, 1, 0, 1, 0, 1]),
-    "Test": np.array([0, 1, 0, 1, 0, 0]),
+    "Test": np.array([0, 1, 0, 0]),
 }
 
 fig = rk.create_calibration_curve(
@@ -103,8 +103,6 @@ fig = rk.create_calibration_curve(
 fig.show()
 ```
 
-::: {.callout-warning}
-The calibration example above deliberately uses equally sized Train and Test populations. The current calibration implementation can reject differently sized populations even when the analogous ROC, precision-recall, or decision-curve call works. See [Curve API Compatibility](curve-api-compatibility.html) for the documented constraint and an intentional failure example.
-:::
+Here, `Train` contains six observations and `Test` contains four. This matching-key contract is supported by calibration as well as the other curve families.
 
-From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](naming-conventions.html) guide explains how the exported function families fit together, while [Curve API Compatibility](curve-api-compatibility.html) documents where those families intentionally or currently differ.
+From here, use the API Reference for the full set of curve types, parameters, and time-to-event variants. The [Naming Conventions](naming-conventions.html) guide explains how the exported function families fit together, while [Curve API Compatibility](curve-api-compatibility.html) documents where those families still differ.

--- a/user_guide/02-curve-api-compatibility.qmd
+++ b/user_guide/02-curve-api-compatibility.qmd
@@ -13,12 +13,14 @@ This page makes those differences explicit so that users — and coding agents r
 |---|---|---|---|---|
 | ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
 | Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
+| Gains | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
+| Lift | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
 | Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Calibration | Supported with matching population keys | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Integer and floating-point values supported |
+| Calibration | Supported | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Integer and floating-point values supported |
 
-## Calibration with named populations
+## Multiple named populations
 
-Matching dictionary keys are paired population-by-population. Each probability vector must match the outcome vector for its own population, but populations may have different sample sizes.
+The curve families accept named probability arrays, so populations such as Train and Test can be evaluated together. When outcomes are also supplied as a dictionary, matching dictionary keys are paired population-by-population. Each probability vector must match the outcome vector for its own population, but different populations may have different sample sizes.
 
 ```python
 import numpy as np
@@ -36,19 +38,31 @@ reals = {
 fig = rk.create_calibration_curve(probs=probs, reals=reals)
 ```
 
-In this example, Train has six observations and Test has four. That is supported. What matters is:
+Here Train has six observations and Test has four. That is supported. What matters is the within-population alignment:
 
 ```text
 len(probs["Train"]) == len(reals["Train"])
 len(probs["Test"])  == len(reals["Test"])
 ```
 
+The same named-population pattern is used by ROC, precision-recall, Gains, Lift, decision, and calibration curve families. For time-dependent calls, `times` follows the same population alignment when supplied as a dictionary.
+
+## Censoring and competing-event heuristics
+
+Time-dependent functions distinguish censoring from competing events. The heuristic for an outcome type matters only when observations of that type are present:
+
+- If there are no competing events, changing `competing_heuristic` does not change the statistical estimates because there are no competing events for that rule to act on.
+- If there are no censored observations, changing `censoring_heuristic` does not change the statistical estimates because there are no censored observations for that rule to act on.
+- If neither censoring nor competing events are present, the heuristic choices do not alter the estimates.
+
+These statements describe the effect of the heuristics on the estimates. Function-specific input validation still applies: a function can reject an unsupported heuristic combination even when the corresponding outcome type is absent.
+
 ## Time-dependent calibration heuristics
 
-`create_calibration_curve_times()` still differs from its ROC, precision-recall, and decision-curve siblings in two important ways:
+`create_calibration_curve_times()` differs from its ROC, precision-recall, Gains, Lift, and decision-curve siblings in two important ways:
 
 1. `heuristics_sets` is currently required rather than defaulted.
-2. Calibration explicitly rejects `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"` with an `Unsupported calibration heuristics` error instead of silently skipping every requested horizon.
+2. Calibration explicitly rejects unsupported heuristic combinations, including `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"`, with an `Unsupported calibration heuristics` error instead of silently skipping every requested horizon.
 
 Pass the calibration heuristic explicitly. For the currently working exclusion-based path:
 
@@ -79,4 +93,4 @@ fig = rk.create_calibration_curve_times(
 
 ## Related functions
 
-When moving between curve families, compare the API reference for `create_calibration_curve()`, `create_calibration_curve_times()`, `create_roc_curve_times()`, `create_precision_recall_curve_times()`, and `create_decision_curve_times()` rather than assuming their defaults and accepted heuristics are identical.
+When moving between curve families, compare the API reference for the relevant `_times()` functions rather than assuming their defaults and accepted heuristics are identical. In particular, calibration has a narrower heuristic contract than the other time-dependent curve families.

--- a/user_guide/02-curve-api-compatibility.qmd
+++ b/user_guide/02-curve-api-compatibility.qmd
@@ -1,0 +1,115 @@
+---
+title: "Curve API Compatibility"
+guide-section: "Using rtichoke"
+---
+
+`rtichoke` intentionally exposes parallel function families for discrimination, calibration, and decision-curve analysis. Their interfaces are similar, but they are **not interchangeable in every edge case**.
+
+This page makes those differences explicit so that users — and coding agents reading `llms-full.txt` — can choose the right call without experimentally probing each function.
+
+::: {.callout-important}
+## Calibration is the main exception
+
+The current calibration implementation has stricter multi-population behavior than ROC, precision-recall, and decision curves. In particular, do not assume that an input pattern accepted by a discrimination curve is automatically accepted by a calibration curve.
+:::
+
+## Capability matrix
+
+| Function family | Multiple named populations | Unequal population sizes with `dict`/`dict` inputs | Time-dependent heuristic default | `fixed_time_horizons` |
+|---|---|---|---|---|
+| ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
+| Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
+| Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
+| Calibration | Supported when inputs satisfy calibration alignment requirements | **Currently restricted**; differently sized named populations can raise a length-mismatch error | **No default on `create_calibration_curve_times()`**; pass explicitly | Use floating-point values |
+
+The matrix describes the current public behavior. It does **not** claim that every asymmetry is a permanent design decision.
+
+## Calibration with named populations
+
+This symmetric example is supported:
+
+```python
+import numpy as np
+import rtichoke as rk
+
+probs = {
+    "Train": np.array([0.10, 0.90, 0.20, 0.80, 0.30, 0.70]),
+    "Test": np.array([0.15, 0.85, 0.25, 0.75, 0.35, 0.65]),
+}
+reals = {
+    "Train": np.array([0, 1, 0, 1, 0, 1]),
+    "Test": np.array([0, 1, 0, 1, 0, 0]),
+}
+
+fig = rk.create_calibration_curve(probs=probs, reals=reals)
+```
+
+At present, differently sized named populations are not a drop-in equivalent:
+
+```python
+probs = {
+    "Train": np.array([0.10, 0.90, 0.20, 0.80, 0.30, 0.70]),
+    "Test": np.array([0.15, 0.85, 0.25, 0.75]),
+}
+reals = {
+    "Train": np.array([0, 1, 0, 1, 0, 1]),
+    "Test": np.array([0, 1, 0, 0]),
+}
+
+# This input shape can raise a length-mismatch error for calibration.
+rk.create_calibration_curve(probs=probs, reals=reals)
+```
+
+If you need to compare calibration across populations of different sizes, create each calibration curve from its own aligned population rather than assuming the ROC/PR multi-population behavior applies to calibration. See [Common Errors & Fixes](common-errors.html) for the failure pattern.
+
+::: {.callout-note}
+The unequal-population restriction is documented as **current behavior**, not as a statistical recommendation. It should be investigated before adding an escape hatch such as `strict=False` or otherwise changing calibration semantics.
+:::
+
+## Time-dependent calibration heuristics
+
+`create_calibration_curve_times()` differs from its ROC, precision-recall, and decision-curve siblings in two important ways:
+
+1. `heuristics_sets` is currently required rather than defaulted.
+2. The sibling default `censoring_heuristic="adjusted"` is not a safe value to copy blindly into calibration. In the current calibration path, that choice can remove every requested horizon and end in `No data remaining after applying heuristics and time horizons.`
+
+Pass the calibration heuristic explicitly. For the currently working exclusion-based path:
+
+```python
+heuristics_sets = [
+    {
+        "censoring_heuristic": "excluded",
+        "competing_heuristic": "adjusted_as_negative",
+    }
+]
+```
+
+Then call:
+
+```python
+fig = rk.create_calibration_curve_times(
+    probs=probs,
+    reals=reals,
+    times=times,
+    fixed_time_horizons=[3.0, 6.0, 9.0],
+    heuristics_sets=heuristics_sets,
+)
+```
+
+## Time horizons: prefer floats
+
+Use floating-point horizons such as `[3.0, 6.0, 9.0]`, not `[3, 6, 9]`. The current implementation can otherwise expose an internal Polars join-key datatype mismatch (`i64` versus `f64`) rather than a rtichoke-specific validation message.
+
+```python
+# Prefer
+fixed_time_horizons = [3.0, 6.0, 9.0]
+
+# Avoid for now
+fixed_time_horizons = [3, 6, 9]
+```
+
+This is a usability limitation rather than a conceptual requirement; normalizing numeric horizons internally is a good candidate for a small future code fix.
+
+## Related functions
+
+When moving between curve families, compare the API reference for `create_calibration_curve()`, `create_calibration_curve_times()`, `create_roc_curve_times()`, `create_precision_recall_curve_times()`, and `create_decision_curve_times()` rather than assuming their defaults and accepted input shapes are identical.

--- a/user_guide/02-curve-api-compatibility.qmd
+++ b/user_guide/02-curve-api-compatibility.qmd
@@ -3,20 +3,9 @@ title: "Curve API Compatibility"
 guide-section: "Using rtichoke"
 ---
 
-`rtichoke` exposes parallel function families for discrimination, calibration, and decision-curve analysis. Their interfaces are similar, but time-dependent defaults and accepted heuristics are not identical.
+`rtichoke` exposes parallel function families for discrimination, calibration, and decision-curve analysis. Most of them share the same input conventions; the main differences are in time-dependent heuristic handling, especially calibration.
 
-This page makes those differences explicit so that users — and coding agents reading `llms-full.txt` — can choose the right call without experimentally probing each function.
-
-## Capability matrix
-
-| Function family | Multiple named populations | Unequal population sizes with `dict`/`dict` inputs | Time-dependent heuristic default | `fixed_time_horizons` |
-|---|---|---|---|---|
-| ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Gains | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Lift | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
-| Calibration | Supported | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Integer and floating-point values supported |
+This page focuses on the conventions that are shared across curve families and on the few places where users should expect different behavior.
 
 ## Multiple named populations
 

--- a/user_guide/02-curve-api-compatibility.qmd
+++ b/user_guide/02-curve-api-compatibility.qmd
@@ -11,10 +11,10 @@ This page makes those differences explicit so that users — and coding agents r
 
 | Function family | Multiple named populations | Unequal population sizes with `dict`/`dict` inputs | Time-dependent heuristic default | `fixed_time_horizons` |
 |---|---|---|---|---|
-| ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
-| Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
-| Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
-| Calibration | Supported with matching population keys | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Use floating-point values |
+| ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
+| Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
+| Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Integer and floating-point values supported |
+| Calibration | Supported with matching population keys | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Integer and floating-point values supported |
 
 ## Calibration with named populations
 
@@ -48,7 +48,7 @@ len(probs["Test"])  == len(reals["Test"])
 `create_calibration_curve_times()` still differs from its ROC, precision-recall, and decision-curve siblings in two important ways:
 
 1. `heuristics_sets` is currently required rather than defaulted.
-2. The sibling default `censoring_heuristic="adjusted"` is not a safe value to copy blindly into calibration. In the current calibration path, that choice can remove every requested horizon and end in `No data remaining after applying heuristics and time horizons.`
+2. Calibration explicitly rejects `censoring_heuristic="adjusted"` and `competing_heuristic="adjusted_as_censored"` with an `Unsupported calibration heuristics` error instead of silently skipping every requested horizon.
 
 Pass the calibration heuristic explicitly. For the currently working exclusion-based path:
 
@@ -73,19 +73,9 @@ fig = rk.create_calibration_curve_times(
 )
 ```
 
-## Time horizons: prefer floats
+## Numeric time horizons
 
-Use floating-point horizons such as `[3.0, 6.0, 9.0]`, not `[3, 6, 9]`. The current implementation can otherwise expose an internal Polars join-key datatype mismatch (`i64` versus `f64`) rather than a rtichoke-specific validation message.
-
-```python
-# Prefer
-fixed_time_horizons = [3.0, 6.0, 9.0]
-
-# Avoid for now
-fixed_time_horizons = [3, 6, 9]
-```
-
-This is a usability limitation rather than a conceptual requirement; normalizing numeric horizons internally is a good candidate for a small future code fix.
+`fixed_time_horizons` accepts integer or floating-point numeric values. Integer horizons are normalized to floats at the shared time-dependent processing boundary, so `[3, 6, 9]` and `[3.0, 6.0, 9.0]` are equivalent.
 
 ## Related functions
 

--- a/user_guide/02-curve-api-compatibility.qmd
+++ b/user_guide/02-curve-api-compatibility.qmd
@@ -3,15 +3,9 @@ title: "Curve API Compatibility"
 guide-section: "Using rtichoke"
 ---
 
-`rtichoke` intentionally exposes parallel function families for discrimination, calibration, and decision-curve analysis. Their interfaces are similar, but they are **not interchangeable in every edge case**.
+`rtichoke` exposes parallel function families for discrimination, calibration, and decision-curve analysis. Their interfaces are similar, but time-dependent defaults and accepted heuristics are not identical.
 
 This page makes those differences explicit so that users — and coding agents reading `llms-full.txt` — can choose the right call without experimentally probing each function.
-
-::: {.callout-important}
-## Calibration is the main exception
-
-The current calibration implementation has stricter multi-population behavior than ROC, precision-recall, and decision curves. In particular, do not assume that an input pattern accepted by a discrimination curve is automatically accepted by a calibration curve.
-:::
 
 ## Capability matrix
 
@@ -20,33 +14,16 @@ The current calibration implementation has stricter multi-population behavior th
 | ROC | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
 | Precision-recall | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
 | Decision curve | Supported | Supported | `adjusted` / `adjusted_as_negative` | Use floating-point values |
-| Calibration | Supported when inputs satisfy calibration alignment requirements | **Currently restricted**; differently sized named populations can raise a length-mismatch error | **No default on `create_calibration_curve_times()`**; pass explicitly | Use floating-point values |
-
-The matrix describes the current public behavior. It does **not** claim that every asymmetry is a permanent design decision.
+| Calibration | Supported with matching population keys | Supported | **No default on `create_calibration_curve_times()`**; pass explicitly | Use floating-point values |
 
 ## Calibration with named populations
 
-This symmetric example is supported:
+Matching dictionary keys are paired population-by-population. Each probability vector must match the outcome vector for its own population, but populations may have different sample sizes.
 
 ```python
 import numpy as np
 import rtichoke as rk
 
-probs = {
-    "Train": np.array([0.10, 0.90, 0.20, 0.80, 0.30, 0.70]),
-    "Test": np.array([0.15, 0.85, 0.25, 0.75, 0.35, 0.65]),
-}
-reals = {
-    "Train": np.array([0, 1, 0, 1, 0, 1]),
-    "Test": np.array([0, 1, 0, 1, 0, 0]),
-}
-
-fig = rk.create_calibration_curve(probs=probs, reals=reals)
-```
-
-At present, differently sized named populations are not a drop-in equivalent:
-
-```python
 probs = {
     "Train": np.array([0.10, 0.90, 0.20, 0.80, 0.30, 0.70]),
     "Test": np.array([0.15, 0.85, 0.25, 0.75]),
@@ -56,19 +33,19 @@ reals = {
     "Test": np.array([0, 1, 0, 0]),
 }
 
-# This input shape can raise a length-mismatch error for calibration.
-rk.create_calibration_curve(probs=probs, reals=reals)
+fig = rk.create_calibration_curve(probs=probs, reals=reals)
 ```
 
-If you need to compare calibration across populations of different sizes, create each calibration curve from its own aligned population rather than assuming the ROC/PR multi-population behavior applies to calibration. See [Common Errors & Fixes](common-errors.html) for the failure pattern.
+In this example, Train has six observations and Test has four. That is supported. What matters is:
 
-::: {.callout-note}
-The unequal-population restriction is documented as **current behavior**, not as a statistical recommendation. It should be investigated before adding an escape hatch such as `strict=False` or otherwise changing calibration semantics.
-:::
+```text
+len(probs["Train"]) == len(reals["Train"])
+len(probs["Test"])  == len(reals["Test"])
+```
 
 ## Time-dependent calibration heuristics
 
-`create_calibration_curve_times()` differs from its ROC, precision-recall, and decision-curve siblings in two important ways:
+`create_calibration_curve_times()` still differs from its ROC, precision-recall, and decision-curve siblings in two important ways:
 
 1. `heuristics_sets` is currently required rather than defaulted.
 2. The sibling default `censoring_heuristic="adjusted"` is not a safe value to copy blindly into calibration. In the current calibration path, that choice can remove every requested horizon and end in `No data remaining after applying heuristics and time horizons.`
@@ -112,4 +89,4 @@ This is a usability limitation rather than a conceptual requirement; normalizing
 
 ## Related functions
 
-When moving between curve families, compare the API reference for `create_calibration_curve()`, `create_calibration_curve_times()`, `create_roc_curve_times()`, `create_precision_recall_curve_times()`, and `create_decision_curve_times()` rather than assuming their defaults and accepted input shapes are identical.
+When moving between curve families, compare the API reference for `create_calibration_curve()`, `create_calibration_curve_times()`, `create_roc_curve_times()`, `create_precision_recall_curve_times()`, and `create_decision_curve_times()` rather than assuming their defaults and accepted heuristics are identical.

--- a/user_guide/03-common-errors.qmd
+++ b/user_guide/03-common-errors.qmd
@@ -5,19 +5,22 @@ guide-section: "Using rtichoke"
 
 This page is deliberately keyed by **literal error text**. If an rtichoke call fails, search this page for a distinctive part of the exception before tracing into the implementation.
 
-## `probs['...'] length=... does not match sum of population sizes=...`
+## Population key or length mismatch
 
-### Where this commonly appears
+For matching `probs` and `reals` dictionaries, rtichoke pairs values population-by-population. Different populations may have different sample sizes, but lengths must match within each key.
 
-Calibration calls using dictionaries for both predictions and outcomes, especially when the named populations have different numbers of observations.
+```python
+probs = {
+    "Train": train_probs,
+    "Test": test_probs,
+}
+reals = {
+    "Train": train_outcomes,
+    "Test": test_outcomes,
+}
+```
 
-### Why it happens
-
-The current calibration path has stricter alignment requirements than ROC, precision-recall, and decision curves. An input pattern that works for those sibling functions can therefore fail for `create_calibration_curve()` or `create_calibration_curve_times()`.
-
-### Fix
-
-First verify that every prediction vector corresponds to the intended outcome population. If you are deliberately comparing differently sized populations, do not assume calibration supports the same dict/dict overlay pattern as ROC or PR. Create the calibration result for each aligned population separately.
+Check that the keys match and that each pair has equal length. Unequal Train/Test sample sizes are supported.
 
 See [Curve API Compatibility](curve-api-compatibility.html) for the family-by-family comparison.
 
@@ -87,4 +90,4 @@ heuristics_sets = [
 
 ## Still stuck?
 
-Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important debugging rule is that similarly named rtichoke curve functions can still differ in accepted population shapes, heuristic defaults, and time-horizon handling.
+Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important remaining differences are heuristic defaults and time-horizon handling, not unequal population sizes.

--- a/user_guide/03-common-errors.qmd
+++ b/user_guide/03-common-errors.qmd
@@ -20,7 +20,7 @@ reals = {
 }
 ```
 
-Check that the keys match and that each pair has equal length. Unequal Train/Test sample sizes are supported.
+Check that the keys match and that each pair has equal length. Unequal Train/Test sample sizes are supported across the curve families that accept these inputs. For time-dependent calls, dictionary-valued `times` must follow the same population alignment.
 
 See [Curve API Compatibility](curve-api-compatibility.html) for the family-by-family comparison.
 
@@ -49,8 +49,9 @@ heuristics_sets = [
 ]
 ```
 
-Do not infer calibration defaults from `create_roc_curve_times()`,
-`create_precision_recall_curve_times()`, or `create_decision_curve_times()`.
+Do not infer calibration defaults from the other time-dependent curve families.
+
+A heuristic only changes estimates when the corresponding outcome type is present: a competing-event rule has no statistical effect when there are no competing events, and a censoring rule has no statistical effect when there is no censoring. Input validation is separate from this statistical point, so unsupported calibration combinations can still be rejected even when the relevant outcome type is absent.
 
 ## `No data remaining after applying heuristics and time horizons.`
 
@@ -76,7 +77,7 @@ fixed_time_horizons=[3.0, 6.0, 9.0]
 
 ## Why is `heuristics_sets` missing?
 
-If Python reports that `create_calibration_curve_times()` is missing the required `heuristics_sets` argument, that is currently expected API behavior. Unlike the ROC, precision-recall, and decision-curve `_times` functions, calibration does not currently provide a default.
+If Python reports that `create_calibration_curve_times()` is missing the required `heuristics_sets` argument, that is currently expected API behavior. Unlike the ROC, precision-recall, Gains, Lift, and decision-curve `_times` functions, calibration does not currently provide a default.
 
 Pass it explicitly rather than copying a sibling default:
 
@@ -91,4 +92,4 @@ heuristics_sets = [
 
 ## Still stuck?
 
-Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important remaining difference is calibration's required heuristic selection, not unequal population sizes or integer horizons.
+Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important remaining difference is calibration's required and narrower heuristic selection, not unequal population sizes or integer horizons.

--- a/user_guide/03-common-errors.qmd
+++ b/user_guide/03-common-errors.qmd
@@ -24,19 +24,21 @@ Check that the keys match and that each pair has equal length. Unequal Train/Tes
 
 See [Curve API Compatibility](curve-api-compatibility.html) for the family-by-family comparison.
 
-## `No data remaining after applying heuristics and time horizons.`
+## `Unsupported calibration heuristics`
 
-### Where this commonly appears
+### Where this appears
 
 `create_calibration_curve_times()`.
 
 ### Why it happens
 
-One current failure mode is passing the heuristic combination used as the default by ROC/PR/decision time-dependent functions. In calibration, `censoring_heuristic="adjusted"` can skip every horizon, leaving no data to plot. The final exception does not currently explain which heuristic caused the removal.
+Calibration does not currently implement `censoring_heuristic="adjusted"` or
+`competing_heuristic="adjusted_as_censored"`. These inputs are rejected
+before curve construction rather than silently skipping every requested horizon.
 
 ### Fix
 
-Pass the calibration heuristic explicitly. For the currently working exclusion-based path:
+Pass a supported calibration heuristic explicitly. For the exclusion-based path:
 
 ```python
 heuristics_sets = [
@@ -47,31 +49,30 @@ heuristics_sets = [
 ]
 ```
 
-Do not infer calibration defaults from `create_roc_curve_times()`, `create_precision_recall_curve_times()`, or `create_decision_curve_times()`.
+Do not infer calibration defaults from `create_roc_curve_times()`,
+`create_precision_recall_curve_times()`, or `create_decision_curve_times()`.
 
-## Polars join-key datatype mismatch: `i64` versus `f64`
+## `No data remaining after applying heuristics and time horizons.`
 
-### Where this commonly appears
+Unsupported calibration heuristics now raise the targeted error above. If this
+message still appears, the supported heuristic and horizon combination removed
+all observations. Check the observed times, event values, requested horizons,
+and exclusion rules.
 
-Time-dependent functions when integer values are supplied in `fixed_time_horizons`, for example:
+## Integer and floating-point time horizons
+
+`fixed_time_horizons` accepts integer and floating-point numeric values.
+Integer horizons are normalized to floats internally:
 
 ```python
 fixed_time_horizons=[3, 6, 9]
 ```
 
-### Why it happens
-
-The current internal time-horizon data can be floating point, while integer literals create integer-typed join keys. The resulting Polars error leaks an implementation detail instead of explaining the rtichoke input requirement.
-
-### Fix
-
-Use floating-point horizons:
+is equivalent to:
 
 ```python
 fixed_time_horizons=[3.0, 6.0, 9.0]
 ```
-
-Internal numeric normalization is a candidate for a future defensive code fix.
 
 ## Why is `heuristics_sets` missing?
 
@@ -90,4 +91,4 @@ heuristics_sets = [
 
 ## Still stuck?
 
-Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important remaining differences are heuristic defaults and time-horizon handling, not unequal population sizes.
+Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important remaining difference is calibration's required heuristic selection, not unequal population sizes or integer horizons.

--- a/user_guide/03-common-errors.qmd
+++ b/user_guide/03-common-errors.qmd
@@ -1,0 +1,90 @@
+---
+title: "Common Errors & Fixes"
+guide-section: "Using rtichoke"
+---
+
+This page is deliberately keyed by **literal error text**. If an rtichoke call fails, search this page for a distinctive part of the exception before tracing into the implementation.
+
+## `probs['...'] length=... does not match sum of population sizes=...`
+
+### Where this commonly appears
+
+Calibration calls using dictionaries for both predictions and outcomes, especially when the named populations have different numbers of observations.
+
+### Why it happens
+
+The current calibration path has stricter alignment requirements than ROC, precision-recall, and decision curves. An input pattern that works for those sibling functions can therefore fail for `create_calibration_curve()` or `create_calibration_curve_times()`.
+
+### Fix
+
+First verify that every prediction vector corresponds to the intended outcome population. If you are deliberately comparing differently sized populations, do not assume calibration supports the same dict/dict overlay pattern as ROC or PR. Create the calibration result for each aligned population separately.
+
+See [Curve API Compatibility](curve-api-compatibility.html) for the family-by-family comparison.
+
+## `No data remaining after applying heuristics and time horizons.`
+
+### Where this commonly appears
+
+`create_calibration_curve_times()`.
+
+### Why it happens
+
+One current failure mode is passing the heuristic combination used as the default by ROC/PR/decision time-dependent functions. In calibration, `censoring_heuristic="adjusted"` can skip every horizon, leaving no data to plot. The final exception does not currently explain which heuristic caused the removal.
+
+### Fix
+
+Pass the calibration heuristic explicitly. For the currently working exclusion-based path:
+
+```python
+heuristics_sets = [
+    {
+        "censoring_heuristic": "excluded",
+        "competing_heuristic": "adjusted_as_negative",
+    }
+]
+```
+
+Do not infer calibration defaults from `create_roc_curve_times()`, `create_precision_recall_curve_times()`, or `create_decision_curve_times()`.
+
+## Polars join-key datatype mismatch: `i64` versus `f64`
+
+### Where this commonly appears
+
+Time-dependent functions when integer values are supplied in `fixed_time_horizons`, for example:
+
+```python
+fixed_time_horizons=[3, 6, 9]
+```
+
+### Why it happens
+
+The current internal time-horizon data can be floating point, while integer literals create integer-typed join keys. The resulting Polars error leaks an implementation detail instead of explaining the rtichoke input requirement.
+
+### Fix
+
+Use floating-point horizons:
+
+```python
+fixed_time_horizons=[3.0, 6.0, 9.0]
+```
+
+Internal numeric normalization is a candidate for a future defensive code fix.
+
+## Why is `heuristics_sets` missing?
+
+If Python reports that `create_calibration_curve_times()` is missing the required `heuristics_sets` argument, that is currently expected API behavior. Unlike the ROC, precision-recall, and decision-curve `_times` functions, calibration does not currently provide a default.
+
+Pass it explicitly rather than copying a sibling default:
+
+```python
+heuristics_sets = [
+    {
+        "censoring_heuristic": "excluded",
+        "competing_heuristic": "adjusted_as_negative",
+    }
+]
+```
+
+## Still stuck?
+
+Check [Curve API Compatibility](curve-api-compatibility.html) first. The most important debugging rule is that similarly named rtichoke curve functions can still differ in accepted population shapes, heuristic defaults, and time-horizon handling.


### PR DESCRIPTION
## What changed

- adds a focused Curve API Compatibility guide covering shared population conventions and the remaining time-dependent differences
- adds a Common Errors & Fixes guide keyed by literal exception text
- documents the supported matching-key multi-population contract introduced by #291
- documents integer `fixed_time_horizons` support introduced by #292
- documents the targeted unsupported-calibration-heuristics error introduced by #293
- clarifies when censoring and competing-event heuristics are statistically irrelevant because the corresponding outcome type is absent
- enables Great Docs' GitHub-release-backed changelog
- adds a curated `skills/rtichoke/SKILL.md` so Great Docs can publish package-specific agent guidance alongside `llms.txt` / `llms-full.txt`

## Why

Recent integration work exposed several places where similarly named rtichoke functions have different behavioral contracts. The docs should emphasize the conventions the curve families share and make the real remaining asymmetries discoverable without overstating differences.

After #291, matching-key Train/Test populations may have different sample sizes. After #292, integer and floating-point fixed time horizons are equivalent. After #293, unsupported calibration heuristics fail early with an actionable error. The main remaining API asymmetry documented here is that `create_calibration_curve_times()` requires an explicit `heuristics_sets` argument and accepts a narrower set of heuristics than its sibling curve families.

## Great Docs integration

The new user-guide pages flow into `llms-full.txt`; the curated skill captures high-value gotchas in a compact agent-oriented form; and the changelog is sourced from GitHub Releases rather than maintained as duplicate history.

## Scope

Documentation only. This PR does not change calibration defaults or statistical behavior.