### PR TITLE
Normalize integer fixed time horizons

### DIFF
--- a/src/rtichoke/performance_data/performance_data_times.py
+++ b/src/rtichoke/performance_data/performance_data_times.py
@@ -59,7 +59,8 @@ def prepare_performance_data_times(
         The event or censoring times corresponding to the `reals`. Can be a
         single array or a dictionary.
     fixed_time_horizons : list[float]
-        A list of time points at which to evaluate the model's performance.
+        A list of numeric time points at which to evaluate the model's
+        performance. Integer inputs are accepted and normalized to floats.
     heuristics_sets : list[Dict], optional
         A list of dictionaries, each specifying how to handle censored data
         and competing events. The default is
@@ -134,7 +135,8 @@ def prepare_binned_classification_data_times(
     times : Union[np.ndarray, Dict[str, np.ndarray]]
         The event or censoring times.
     fixed_time_horizons : list[float]
-        A list of time points for performance evaluation.
+        A list of numeric time points for performance evaluation. Integer
+        inputs are accepted and normalized to floats.
     heuristics_sets : list[Dict], optional
         Specifies how to handle censored data and competing events.
     stratified_by : Sequence[str], optional
@@ -152,6 +154,8 @@ def prepare_binned_classification_data_times(
         represents a unique combination of dataset, bin, time horizon,
         heuristic, and other strata.
     """
+    fixed_time_horizons = [float(horizon) for horizon in fixed_time_horizons]
+
     breaks = create_breaks_values(None, "probability_threshold", by)
 
     aj_data_combinations = create_aj_data_combinations(


### PR DESCRIPTION
## What changed

- normalizes `fixed_time_horizons` to floats at the shared `prepare_binned_classification_data_times()` entry point
- makes integer horizons such as `[3, 6, 9]` equivalent to `[3.0, 6.0, 9.0]`
- updates the time-dependent performance-data docstrings to describe numeric horizons rather than requiring callers to know the internal dtype

## Why

Integer horizons could previously propagate as `i64` while downstream time/AJ data used `f64`, leaking an opaque Polars join-key datatype mismatch. The public API should treat integer and floating-point representations of the same time horizon identically.

## Scope

This PR only addresses horizon normalization in the shared time-dependent performance-data path. It does not change calibration heuristic behavior or defaults.