### PR TITLE
Raise actionable errors for unsupported calibration heuristics

### DIFF
--- a/src/rtichoke/__init__.py
+++ b/src/rtichoke/__init__.py
@@ -30,7 +30,7 @@ from rtichoke.discrimination.gains import (
 )
 from rtichoke.discrimination.gains import plot_gains_curve as plot_gains_curve
 
-from rtichoke.calibration.calibration import (
+from rtichoke.calibration import (
     create_calibration_curve as create_calibration_curve,
     create_calibration_curve_times as create_calibration_curve_times,
 )

--- a/src/rtichoke/calibration/__init__.py
+++ b/src/rtichoke/calibration/__init__.py
@@ -2,6 +2,37 @@
 Subpackage for Calibration
 """
 
-from .calibration import create_calibration_curve, create_calibration_curve_times
+from functools import wraps
+from inspect import signature
+
+from .calibration import create_calibration_curve
+from .calibration import create_calibration_curve_times as _create_calibration_curve_times
+
+
+@wraps(_create_calibration_curve_times)
+def create_calibration_curve_times(*args, **kwargs):
+    bound = signature(_create_calibration_curve_times).bind_partial(*args, **kwargs)
+    heuristics_sets = bound.arguments.get("heuristics_sets")
+
+    if heuristics_sets is not None:
+        unsupported = [
+            heuristics
+            for heuristics in heuristics_sets
+            if heuristics.get("censoring_heuristic") == "adjusted"
+            or heuristics.get("competing_heuristic") == "adjusted_as_censored"
+        ]
+        if unsupported:
+            raise ValueError(
+                "Unsupported calibration heuristics: "
+                "create_calibration_curve_times() does not support "
+                "censoring_heuristic='adjusted' or "
+                "competing_heuristic='adjusted_as_censored'. "
+                "Use a supported heuristic combination such as "
+                "censoring_heuristic='excluded' with "
+                "competing_heuristic='adjusted_as_negative'."
+            )
+
+    return _create_calibration_curve_times(*args, **kwargs)
+
 
 __all__ = ["create_calibration_curve", "create_calibration_curve_times"]

--- a/src/rtichoke/calibration/__init__.py
+++ b/src/rtichoke/calibration/__init__.py
@@ -2,37 +2,6 @@
 Subpackage for Calibration
 """
 
-from functools import wraps
-from inspect import signature
-
-from .calibration import create_calibration_curve
-from .calibration import create_calibration_curve_times as _create_calibration_curve_times
-
-
-@wraps(_create_calibration_curve_times)
-def create_calibration_curve_times(*args, **kwargs):
-    bound = signature(_create_calibration_curve_times).bind_partial(*args, **kwargs)
-    heuristics_sets = bound.arguments.get("heuristics_sets")
-
-    if heuristics_sets is not None:
-        unsupported = [
-            heuristics
-            for heuristics in heuristics_sets
-            if heuristics.get("censoring_heuristic") == "adjusted"
-            or heuristics.get("competing_heuristic") == "adjusted_as_censored"
-        ]
-        if unsupported:
-            raise ValueError(
-                "Unsupported calibration heuristics: "
-                "create_calibration_curve_times() does not support "
-                "censoring_heuristic='adjusted' or "
-                "competing_heuristic='adjusted_as_censored'. "
-                "Use a supported heuristic combination such as "
-                "censoring_heuristic='excluded' with "
-                "competing_heuristic='adjusted_as_negative'."
-            )
-
-    return _create_calibration_curve_times(*args, **kwargs)
-
+from .calibration import create_calibration_curve, create_calibration_curve_times
 
 __all__ = ["create_calibration_curve", "create_calibration_curve_times"]

--- a/src/rtichoke/calibration/calibration.py
+++ b/src/rtichoke/calibration/calibration.py
@@ -99,7 +99,12 @@ def create_calibration_curve_times(
         "#585123",
     ],
 ) -> Figure:
-    """Creates a time-dependent Calibration Curve with a slider for different time horizons."""
+    """Create a time-dependent calibration curve across fixed horizons.
+
+    Raises:
+        ValueError: If a heuristic set requests adjusted censoring or treats
+            competing events as censored, which calibration does not support.
+    """
 
     unsupported = [
         heuristics

--- a/src/rtichoke/calibration/calibration.py
+++ b/src/rtichoke/calibration/calibration.py
@@ -101,6 +101,23 @@ def create_calibration_curve_times(
 ) -> Figure:
     """Creates a time-dependent Calibration Curve with a slider for different time horizons."""
 
+    unsupported = [
+        heuristics
+        for heuristics in heuristics_sets
+        if heuristics.get("censoring_heuristic") == "adjusted"
+        or heuristics.get("competing_heuristic") == "adjusted_as_censored"
+    ]
+    if unsupported:
+        raise ValueError(
+            "Unsupported calibration heuristics: "
+            "create_calibration_curve_times() does not support "
+            "censoring_heuristic='adjusted' or "
+            "competing_heuristic='adjusted_as_censored'. "
+            "Use a supported heuristic combination such as "
+            "censoring_heuristic='excluded' with "
+            "competing_heuristic='adjusted_as_negative'."
+        )
+
     calibration_curve_list_times = _create_calibration_curve_list_times(
         probs,
         reals,

--- a/tests/test_calibration_times.py
+++ b/tests/test_calibration_times.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from rtichoke.calibration import create_calibration_curve_times
 
 
@@ -53,3 +54,23 @@ def test_create_calibration_curve_times_unequal_size_populations():
     )
 
     assert {trace.name for trace in fig.data if trace.name} >= {"Train", "Test"}
+
+
+def test_create_calibration_curve_times_rejects_adjusted_censoring():
+    probs = {"model_1": np.array([0.1, 0.2, 0.3, 0.4])}
+    reals = np.array([0, 1, 0, 1])
+    times = np.array([1.0, 2.0, 3.0, 4.0])
+
+    with pytest.raises(ValueError, match="does not support censoring_heuristic='adjusted'"):
+        create_calibration_curve_times(
+            probs,
+            reals,
+            times,
+            fixed_time_horizons=[2.0],
+            heuristics_sets=[
+                {
+                    "censoring_heuristic": "adjusted",
+                    "competing_heuristic": "adjusted_as_negative",
+                }
+            ],
+        )

--- a/tests/test_calibration_times.py
+++ b/tests/test_calibration_times.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
+from rtichoke import create_calibration_curve_times as create_calibration_curve_times_top_level
 from rtichoke.calibration import create_calibration_curve_times
+from rtichoke.calibration.calibration import (
+    create_calibration_curve_times as create_calibration_curve_times_direct,
+)
 
 
 def test_create_calibration_curve_times():
@@ -56,21 +60,35 @@ def test_create_calibration_curve_times_unequal_size_populations():
     assert {trace.name for trace in fig.data if trace.name} >= {"Train", "Test"}
 
 
-def test_create_calibration_curve_times_rejects_adjusted_censoring():
+@pytest.mark.parametrize(
+    "entry_point",
+    [create_calibration_curve_times_top_level, create_calibration_curve_times_direct],
+)
+@pytest.mark.parametrize(
+    "heuristics",
+    [
+        {
+            "censoring_heuristic": "adjusted",
+            "competing_heuristic": "adjusted_as_negative",
+        },
+        {
+            "censoring_heuristic": "excluded",
+            "competing_heuristic": "adjusted_as_censored",
+        },
+    ],
+)
+def test_create_calibration_curve_times_rejects_unsupported_heuristics(
+    entry_point, heuristics
+):
     probs = {"model_1": np.array([0.1, 0.2, 0.3, 0.4])}
     reals = np.array([0, 1, 0, 1])
     times = np.array([1.0, 2.0, 3.0, 4.0])
 
-    with pytest.raises(ValueError, match="does not support censoring_heuristic='adjusted'"):
-        create_calibration_curve_times(
+    with pytest.raises(ValueError, match="Unsupported calibration heuristics"):
+        entry_point(
             probs,
             reals,
             times,
             fixed_time_horizons=[2.0],
-            heuristics_sets=[
-                {
-                    "censoring_heuristic": "adjusted",
-                    "competing_heuristic": "adjusted_as_negative",
-                }
-            ],
+            heuristics_sets=[heuristics],
         )


### PR DESCRIPTION
## What changed

- adds early validation for heuristic combinations that `create_calibration_curve_times()` currently skips internally
- raises a targeted error for `censoring_heuristic='adjusted'` and `competing_heuristic='adjusted_as_censored'`
- points users to a supported combination instead of allowing all horizons to be skipped and ending with the generic `No data remaining after applying heuristics and time horizons.` error
- routes the top-level `rtichoke` calibration imports through the calibration package API so the validation applies to the documented public entry point
- adds a regression test for the previously silent `adjusted` case

## Why

The current implementation deliberately skips those heuristic choices, but the final error describes an empty-data symptom rather than the unsupported input that caused it. This PR makes the existing contract explicit without changing calibration statistics or choosing a new default.

## Scope

This PR does not add a default `heuristics_sets` value. Choosing a calibration-specific default is a separate API/statistical decision and should not be bundled with error handling.