### PR TITLE
Release rtichoke 0.1.29

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release package
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.10"
+
+      - name: Read package version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(python - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh release create "v${VERSION}" --target "${GITHUB_SHA}" --generate-notes --title "v${VERSION}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "great-tables>=0.18.0",
 ]
 name = "rtichoke"
-version = "0.1.28"
+version = "0.1.29"
 description = "interactive visualizations for performance of predictive models"
 readme = "README.md"
 


### PR DESCRIPTION
## What changed

- bumps the package version from `0.1.28` to `0.1.29`
- adds a dedicated release workflow that runs only when `pyproject.toml` changes on `main`
- publishes to PyPI using the existing GitHub OIDC trusted-publishing setup
- creates a matching GitHub Release (`v0.1.29`) with generated release notes after a successful publish

## Why

Ordinary package CI intentionally stopped publishing in #283. This restores publishing as an explicit release action tied to a reviewed version bump, so merges to `main` no longer try to republish an existing immutable PyPI version.

## Included work

This release includes the recently merged performance-data sorting, performance tables/Great Tables + Reactable renderers, calibration multi-population fix, integer time-horizon normalization, improved calibration heuristic validation, and the associated Great Docs documentation improvements.

## Validation

The normal package and documentation PR workflows should run before merge. On merge, the new `Release package` workflow will build and publish `0.1.29`, then create the GitHub release.