### PR TITLE
Fix 0.1.29 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths:
       - "pyproject.toml"
+      - ".github/workflows/release.yml"
 
 jobs:
   release:
@@ -25,12 +26,8 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION=$(python - <<'PY'
-          import tomllib
-          with open("pyproject.toml", "rb") as f:
-              print(tomllib.load(f)["project"]["version"])
-          PY
-          )
+          VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n 1)
+          test -n "$VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build package


### PR DESCRIPTION
## What changed

- replaces Python 3.11-only `tomllib` version parsing with a shell extraction that works on the existing Python 3.10 release runner
- lets the release workflow trigger when its own workflow file changes, so this fix can retry the still-unpublished `0.1.29` release without another version bump

## Root cause

The first `Release package` run failed before build/publish because `tomllib` is unavailable in Python 3.10. No package was uploaded to PyPI and no GitHub release was created.

## Expected result

Merging this PR should trigger the corrected release workflow, publish `rtichoke==0.1.29` through the existing OIDC trusted-publishing setup, and create GitHub release `v0.1.29`.