### PR TITLE
Bump version to 0.1.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "great-tables>=0.18.0",
 ]
 name = "rtichoke"
-version = "0.1.30"
+version = "0.1.31"
 description = "interactive visualizations for performance of predictive models"
 readme = "README.md"
 


### PR DESCRIPTION
## What changed

- bumps the package version from `0.1.30` to `0.1.31`

## Validation

- full test suite: `36 passed`
- Ruff: passed

## Lockfile note

The existing lockfile still identifies the local package as `0.1.28` and is stale relative to other dependency changes already on `main`. Regenerating it with the current resolver rewrites more than 1,000 lines of dependency state, so that broader lockfile refresh is intentionally not bundled into this focused patch-version PR.