### PR TITLE
Clamp calibration zoom to probability bounds

### DIFF
--- a/src/rtichoke/calibration/calibration.py
+++ b/src/rtichoke/calibration/calibration.py
@@ -976,9 +976,10 @@ def _define_limits_for_calibration_plot(deciles_dat: pl.DataFrame) -> List[float
             )
         )
 
+    padding = (upper_bound - lower_bound) * 0.05
     return [
-        lower_bound - (upper_bound - lower_bound) * 0.05,
-        upper_bound + (upper_bound - lower_bound) * 0.05,
+        max(0.0, lower_bound - padding),
+        min(1.0, upper_bound + padding),
     ]
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,5 +1,10 @@
 import numpy as np
-from rtichoke.calibration.calibration import create_calibration_curve
+import polars as pl
+
+from rtichoke.calibration.calibration import (
+    _define_limits_for_calibration_plot,
+    create_calibration_curve,
+)
 
 
 def test_create_calibration_curve_smooth():
@@ -43,3 +48,13 @@ def test_create_calibration_curve_multiple_populations_unequal_sizes():
             probs, reals, calibration_type=calibration_type
         )
         assert {trace.name for trace in fig.data if trace.name} >= {"Train", "Test"}
+
+
+def test_calibration_limits_keep_padding_without_leaving_probability_scale():
+    near_zero = pl.DataFrame({"x": [0.01, 0.20], "y": [0.02, 0.70]})
+    near_one = pl.DataFrame({"x": [0.30, 0.99], "y": [0.40, 0.98]})
+    mid_range = pl.DataFrame({"x": [0.20, 0.80], "y": [0.25, 0.75]})
+
+    assert _define_limits_for_calibration_plot(near_zero) == [0.0, 0.7345]
+    assert _define_limits_for_calibration_plot(near_one) == [0.2655, 1.0]
+    assert _define_limits_for_calibration_plot(mid_range) == [0.17, 0.8300000000000001]


### PR DESCRIPTION
## What changed
- keep the existing 5% calibration-axis padding
- clamp the final padded range to `[0, 1]`
- add regression tests for near-zero, near-one, and mid-range calibration data

## Why
The lower bound was clamped before padding, so the padding step could reintroduce negative probability space. This preserves the intended breathing room without displaying impossible probabilities.

## Scope
No changes to the square-panel behavior or histogram geometry.