### PR TITLE
Use smoothstate from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = [
     {name = "Uriah Finkel"},
 ]
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "plotly<6.0.0,>=5.13.1",
     "pandas>=2.2.3",
@@ -25,7 +25,6 @@ readme = "README.md"
 [dependency-groups]
 dev = [
     "jupyter<2.0.0,>=1.0.0",
-    "myst-nb<1.0.0,>=0.17.1; python_version ~= \"3.9\"",
     "pytest-cov<5.0.0,>=4.0.0",
     "pytest<8.0.0,>=7.3.0",
     "pyzmq<27.0.0,>=26.3.0",
@@ -47,9 +46,6 @@ docs = [
 
 [tool.uv.workspace]
 members = ["rtichoke"]
-
-[tool.uv.sources]
-smoothstate = { git = "https://github.com/uriahf/smoothstate.git", branch = "agent/python-39-compat" }
 
 [tool.uv.dependency-groups]
 docs = {requires-python = ">=3.11"}


### PR DESCRIPTION
Follow-up to #315 now that `smoothstate 0.1.0` is released.

- remove the temporary GitHub source override for `smoothstate`;
- require Python >=3.10, matching `smoothstate`;
- remove the Python-3.9-only `myst-nb` workaround;
- keep `smoothstate>=0.1.0` as the normal runtime dependency.

CI now validates installation through the package index rather than the temporary Git branch.