### PR TITLE
Trim unused runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,8 @@ requires-python = ">=3.10"
 dependencies = [
     "plotly<6.0.0,>=5.13.1",
     "pandas>=2.2.3",
-    "typing>=3.7.4.3",
     "polarstate==0.1.8",
     "smoothstate>=0.1.0",
-    "marimo>=0.17.0",
-    "pyarrow>=21.0.0",
     "statsmodels>=0.14.0",
     "polars>=1.31.0",
     "reactable>=0.1.5",


### PR DESCRIPTION
Remove three dependencies that are no longer needed by the installed rtichoke runtime:

- `typing`: redundant now that rtichoke requires Python >=3.10 and uses the stdlib module;
- `pyarrow`: no direct code usage remains in the repository;
- `marimo`: no runtime package code imports it; it remains in the dev group for documentation/examples.

This deliberately keeps `statsmodels` because the pseudo-value/LOWESS calibration path still uses it, and keeps `pandas`, `reactable`, and `great-tables` because runtime modules still use them.