### PR TITLE
Remove pandas as direct runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
     "plotly<6.0.0,>=5.13.1",
-    "pandas>=2.2.3",
     "polarstate==0.1.8",
     "smoothstate>=0.1.1",
     "polars>=1.31.0",


### PR DESCRIPTION
Remove pandas from rtichoke's direct runtime dependencies. The active performance/calibration pipeline is already Polars/NumPy-based. This PR intentionally starts with the dependency declaration only so CI can verify whether any remaining legacy pandas imports are actually exercised or supplied transitively. If CI exposes a real import dependency, we will replace/remove that specific legacy path rather than changing active algorithms.