### PR TITLE
Fix documentation preview concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: documentation-deployments
+  group: documentation-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Give each pull request its own documentation concurrency group while keeping `main` documentation runs serialized.

The previous repository-wide `documentation-deployments` group caused unrelated PR preview runs to compete for the same pending slot and get cancelled before any job started.

GitHub Actions concurrency groups allow expressions, and separate group names prevent unrelated workflow runs from blocking/cancelling each other.

After this is merged, PR documentation previews should be able to run independently.