### PR TITLE
Honor size in time-dependent curves

### DIFF
--- a/src/rtichoke/discrimination/roc.py
+++ b/src/rtichoke/discrimination/roc.py
@@ -5,9 +5,11 @@ A module for ROC Curves
 from typing import Dict, List, Union, Sequence
 from plotly.graph_objs._figure import Figure
 from rtichoke.processing.plotly_helper_functions import (
-    _create_rtichoke_plotly_curve_times,
     _create_rtichoke_plotly_curve_binary,
     _plot_rtichoke_curve_binary,
+)
+from rtichoke.processing.time_reference_lines import (
+    _create_rtichoke_plotly_curve_times_reference_safe,
 )
 import numpy as np
 import polars as pl
@@ -195,7 +197,7 @@ def create_roc_curve_times(
         A Plotly ``Figure`` object representing the time-dependent ROC curve.
     """
 
-    fig = _create_rtichoke_plotly_curve_times(
+    fig = _create_rtichoke_plotly_curve_times_reference_safe(
         probs,
         reals,
         times,

--- a/src/rtichoke/processing/time_reference_lines.py
+++ b/src/rtichoke/processing/time_reference_lines.py
@@ -83,6 +83,7 @@ def _create_rtichoke_plotly_curve_times_reference_safe(
     curve_list = _create_rtichoke_curve_list_times(
         performance_data,
         stratified_by=stratified_by[0],
+        size=size,
         curve=curve,
         min_p_threshold=min_p_threshold,
         max_p_threshold=max_p_threshold,

--- a/tests/test_time_curve_size.py
+++ b/tests/test_time_curve_size.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from rtichoke import (
+    create_decision_curve_times,
+    create_lift_curve_times,
+    create_precision_recall_curve_times,
+    create_roc_curve_times,
+)
+
+
+@pytest.mark.parametrize(
+    "curve_function",
+    [
+        create_roc_curve_times,
+        create_precision_recall_curve_times,
+        create_lift_curve_times,
+        create_decision_curve_times,
+    ],
+)
+def test_time_curve_size_is_forwarded_to_plot_layout(curve_function):
+    probs = {"model": np.array([0.05, 0.20, 0.40, 0.60, 0.80, 0.95])}
+    reals = np.array([1, 0, 1, 0, 1, 0])
+    times = np.array([1.0, 10.0, 2.0, 11.0, 3.0, 12.0])
+
+    fig = curve_function(
+        probs,
+        reals,
+        times,
+        fixed_time_horizons=[5.0],
+        size=420,
+        by=0.1,
+    )
+
+    assert fig.layout.width == 420
+    assert fig.layout.height == 520


### PR DESCRIPTION
## Summary
- forward the public `size` argument into the shared time-dependent curve layout
- route time-dependent ROC through the same size-aware helper already used by PR/Lift/Decision
- add regression coverage for ROC, Precision-Recall, Lift, and Decision public APIs

## Why
The `*_times` APIs accepted `size`, but the shared plotting path fell back to `_create_rtichoke_curve_list_times()`'s default size of 500. As a result, explicit values such as `size=420` were ignored.

## Scope
No metric calculations, heuristics, reference formulas, colors, or sorting behavior are changed.