### PR TITLE
Validate probability and outcome domains

### DIFF
--- a/src/rtichoke/performance_data/performance_data.py
+++ b/src/rtichoke/performance_data/performance_data.py
@@ -53,6 +53,12 @@ def _validate_and_align_binary_inputs(
         raise ValueError("`probs` must be a non-empty dictionary of probability arrays.")
 
     groups = list(probs)
+    for group in groups:
+        probs_values = np.asarray(probs[group])
+        if not np.all(np.isfinite(probs_values)) or np.any(
+            (probs_values < 0) | (probs_values > 1)
+        ):
+            raise ValueError("Estimated probabilities must be between 0 and 1.")
 
     if isinstance(reals, dict):
         expected_keys = set(groups)
@@ -60,20 +66,27 @@ def _validate_and_align_binary_inputs(
             raise ValueError("`reals` dictionary keys must exactly match `probs`.")
 
         for group in groups:
+            reals_values = np.asarray(reals[group])
             n_probs = len(np.asarray(probs[group]))
-            n_reals = len(np.asarray(reals[group]))
+            n_reals = len(reals_values)
             if n_probs != n_reals:
                 raise ValueError(
                     f"Input lengths must match within group {group!r}: "
                     f"len(probs)={n_probs}, len(reals)={n_reals}."
                 )
+            if not np.all(np.isin(reals_values, [0, 1])):
+                raise ValueError("Binary outcomes must contain only 0 and 1.")
 
         if len(groups) == 1:
             return np.asarray(reals[groups[0]])
 
         return {group: np.asarray(reals[group]) for group in groups}
 
-    n_reals = len(np.asarray(reals))
+    reals_values = np.asarray(reals)
+    if not np.all(np.isin(reals_values, [0, 1])):
+        raise ValueError("Binary outcomes must contain only 0 and 1.")
+
+    n_reals = len(reals_values)
     for group in groups:
         n_probs = len(np.asarray(probs[group]))
         if n_probs != n_reals:

--- a/src/rtichoke/processing/time_input_validation.py
+++ b/src/rtichoke/processing/time_input_validation.py
@@ -5,6 +5,26 @@ from typing import Dict, Union
 import numpy as np
 
 
+def _validate_probability_values(probs: Dict[str, np.ndarray]) -> None:
+    for values in probs.values():
+        probs_values = np.asarray(values)
+        if not np.all(np.isfinite(probs_values)) or np.any(
+            (probs_values < 0) | (probs_values > 1)
+        ):
+            raise ValueError("Estimated probabilities must be between 0 and 1.")
+
+
+def _validate_time_outcome_values(
+    reals: Union[np.ndarray, Dict[str, np.ndarray]],
+) -> None:
+    values = reals.values() if isinstance(reals, dict) else [reals]
+    for outcome_values in values:
+        if not np.all(np.isin(np.asarray(outcome_values), [0, 1, 2])):
+            raise ValueError(
+                "Time-dependent outcomes must contain only 0, 1, and 2."
+            )
+
+
 def _validate_time_input_alignment(
     probs: Dict[str, np.ndarray],
     reals: Union[np.ndarray, Dict[str, np.ndarray]],
@@ -13,6 +33,9 @@ def _validate_time_input_alignment(
     """Validate supported array/dict layouts before time-dependent processing."""
     if not isinstance(probs, dict) or not probs:
         raise ValueError("`probs` must be a non-empty dictionary of probability arrays.")
+
+    _validate_probability_values(probs)
+    _validate_time_outcome_values(reals)
 
     groups = list(probs)
     multiple_groups = len(groups) > 1

--- a/tests/test_input_domain_validation.py
+++ b/tests/test_input_domain_validation.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from rtichoke import prepare_performance_data, prepare_performance_data_times
+
+
+def test_binary_probabilities_must_be_in_unit_interval():
+    with pytest.raises(ValueError, match="probabilities must be between 0 and 1"):
+        prepare_performance_data(
+            probs={"model": np.array([0.1, 1.1])},
+            reals=np.array([0, 1]),
+            by=0.5,
+        )
+
+
+def test_binary_outcomes_must_be_zero_or_one():
+    with pytest.raises(ValueError, match="binary outcomes must contain only 0 and 1"):
+        prepare_performance_data(
+            probs={"model": np.array([0.1, 0.9])},
+            reals=np.array([0, 2]),
+            by=0.5,
+        )
+
+
+def test_time_probabilities_must_be_in_unit_interval():
+    with pytest.raises(ValueError, match="probabilities must be between 0 and 1"):
+        prepare_performance_data_times(
+            probs={"model": np.array([-0.1, 0.9])},
+            reals=np.array([0, 1]),
+            times=np.array([1.0, 2.0]),
+            fixed_time_horizons=[1.5],
+            by=0.5,
+        )
+
+
+def test_time_outcomes_must_use_supported_event_codes():
+    with pytest.raises(ValueError, match="time-dependent outcomes must contain only 0, 1, and 2"):
+        prepare_performance_data_times(
+            probs={"model": np.array([0.1, 0.9])},
+            reals=np.array([0, 3]),
+            times=np.array([1.0, 2.0]),
+            fixed_time_horizons=[1.5],
+            by=0.5,
+        )

--- a/tests/test_input_domain_validation.py
+++ b/tests/test_input_domain_validation.py
@@ -5,7 +5,7 @@ from rtichoke import prepare_performance_data, prepare_performance_data_times
 
 
 def test_binary_probabilities_must_be_in_unit_interval():
-    with pytest.raises(ValueError, match="probabilities must be between 0 and 1"):
+    with pytest.raises(ValueError, match="between 0 and 1"):
         prepare_performance_data(
             probs={"model": np.array([0.1, 1.1])},
             reals=np.array([0, 1]),
@@ -14,7 +14,7 @@ def test_binary_probabilities_must_be_in_unit_interval():
 
 
 def test_binary_outcomes_must_be_zero_or_one():
-    with pytest.raises(ValueError, match="binary outcomes must contain only 0 and 1"):
+    with pytest.raises(ValueError, match="only 0 and 1"):
         prepare_performance_data(
             probs={"model": np.array([0.1, 0.9])},
             reals=np.array([0, 2]),
@@ -23,7 +23,7 @@ def test_binary_outcomes_must_be_zero_or_one():
 
 
 def test_time_probabilities_must_be_in_unit_interval():
-    with pytest.raises(ValueError, match="probabilities must be between 0 and 1"):
+    with pytest.raises(ValueError, match="between 0 and 1"):
         prepare_performance_data_times(
             probs={"model": np.array([-0.1, 0.9])},
             reals=np.array([0, 1]),
@@ -34,7 +34,7 @@ def test_time_probabilities_must_be_in_unit_interval():
 
 
 def test_time_outcomes_must_use_supported_event_codes():
-    with pytest.raises(ValueError, match="time-dependent outcomes must contain only 0, 1, and 2"):
+    with pytest.raises(ValueError, match="only 0, 1, and 2"):
         prepare_performance_data_times(
             probs={"model": np.array([0.1, 0.9])},
             reals=np.array([0, 3]),


### PR DESCRIPTION
## Summary
- reject probabilities outside `[0, 1]` before binary or time-dependent binning
- reject binary outcomes outside `{0, 1}`
- reject time-dependent event codes outside `{0, 1, 2}`
- add focused regression tests for both binary and `*_times` paths

## R parity
The R package explicitly validates probability ranges and binary outcome codes before calculation. This brings the Python performance-data APIs in line with that contract and gives the time-dependent path an equivalent event-code check.

## Audit classification
Input-validation / correctness issue: invalid values could reach NumPy/Polars binning or mapping internals and fail inconsistently or misleadingly.

No valid-input calculations, cutoff semantics, estimators, plotting behavior, or dependencies are changed.