### PR TITLE
Enforce Ruff lint in package CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Check lint
         run: uv run ruff check .
 
-      - name: Check formatting
-        run: uv run ruff format --check .
-
       - name: Build package
         run: uv build
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: Check lint
+        run: uv run ruff check .
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
       - name: Build package
         run: uv build
 

--- a/src/rtichoke/discrimination/gains.py
+++ b/src/rtichoke/discrimination/gains.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Sequence, Union
 from plotly.graph_objs._figure import Figure
 from rtichoke.processing.binary_color_values import _apply_color_values_binary
 from rtichoke.processing.plotly_helper_functions import (
-    _create_rtichoke_plotly_curve_times,
     _create_rtichoke_plotly_curve_binary,
     _plot_rtichoke_curve_binary,
     _create_rtichoke_curve_list_times,

--- a/tests/test_decision_curve_dcurves_parity.py
+++ b/tests/test_decision_curve_dcurves_parity.py
@@ -2,7 +2,6 @@
 
 from importlib import resources
 
-import numpy as np
 import polars as pl
 from dcurves import dca
 from numpy.testing import assert_allclose
@@ -40,9 +39,7 @@ def _dcurves_survival_dca(data: pl.DataFrame, thresholds: list[float]):
     # dcurves requires a pandas DataFrame and already depends on pandas itself.
     # Building it from plain Python data avoids adding pyarrow just for
     # `pl.DataFrame.to_pandas()`.
-    pandas_df_type = type(
-        dca.__globals__["pd"].DataFrame()
-    )
+    pandas_df_type = type(dca.__globals__["pd"].DataFrame())
     pandas_data = pandas_df_type(data.to_dict(as_series=False))
 
     return dca(


### PR DESCRIPTION
## Summary
- run `ruff check .` in the Python package workflow
- remove the two pre-existing unused imports found by the baseline lint run

## Scope
Developer tooling only. No runtime dependencies, statistical calculations, or public API changes.

Formatting enforcement is intentionally deferred to a separate follow-up PR because `ruff format --check .` identified 21 files that need a mechanical baseline reformat. Keeping that work separate makes both changes easy to review.