### PR TITLE
Probe ty readiness in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Check format
         run: uv run ruff format --check .
 
+      - name: Check types (non-blocking)
+        continue-on-error: true
+        run: uv run ty check src/rtichoke
+
       - name: Build package
         run: uv build
 


### PR DESCRIPTION
## Summary
- run `uv run ty check src/rtichoke` in package CI
- keep the type-check step non-blocking while we establish the baseline

## Baseline
`ty` reports **11 diagnostics** on the current package source:

- 2 intentional calibration export/shadowing assignments in `calibration/__init__.py`
- 1 internal `times` annotation mismatch in `performance_table.py`
- 4 Polars scalar-narrowing issues around `max()` values used as floats
- 1 Reactable callable/stub mismatch for `details=confusion_matrix`
- 3 NumPy-array vs list annotation mismatches in `processing/combinations.py`

The package CI otherwise passes: Ruff lint, Ruff format, build, and all 137 tests.

## Scope
Developer tooling only. No type fixes, runtime dependencies, API changes, statistical changes, or functional refactoring.

## Recommendation
Keep this probe non-blocking for now. The 11-error baseline is small enough to address incrementally in a follow-up PR; once it reaches zero, make `ty` blocking in CI.