### PR TITLE
Clear ty baseline and enforce type checking

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Check format
         run: uv run ruff format --check .
 
-      - name: Check types (non-blocking)
-        continue-on-error: true
+      - name: Check types
         run: uv run ty check src/rtichoke
 
       - name: Build package

--- a/src/rtichoke/calibration/__init__.py
+++ b/src/rtichoke/calibration/__init__.py
@@ -75,8 +75,9 @@ def create_calibration_curve_times(*args, **kwargs):
 
 
 # Keep direct imports from rtichoke.calibration.calibration aligned with the
-# public package entry points.
-_calibration.create_calibration_curve = create_calibration_curve
-_calibration.create_calibration_curve_times = create_calibration_curve_times
+# public package entry points. setattr preserves the intentional runtime rebinding
+# without presenting it to the type checker as an incompatible function assignment.
+setattr(_calibration, "create_calibration_curve", create_calibration_curve)
+setattr(_calibration, "create_calibration_curve_times", create_calibration_curve_times)
 
 __all__ = ["create_calibration_curve", "create_calibration_curve_times"]

--- a/src/rtichoke/performance_table.py
+++ b/src/rtichoke/performance_table.py
@@ -84,6 +84,7 @@ def create_performance_table_times(
     boundary; fixed-horizon normalization is handled by the shared time-dependent
     performance pipeline.
     """
+    normalized_times: np.ndarray | dict[str, np.ndarray]
     if isinstance(times, dict):
         normalized_times = {
             key: np.asarray(value, dtype=float) for key, value in times.items()

--- a/src/rtichoke/performance_table.py
+++ b/src/rtichoke/performance_table.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Dict, Literal, Union
+from typing import Dict, Literal, Union, cast
 
 import numpy as np
 import polars as pl
@@ -86,9 +86,10 @@ def create_performance_table_times(
     """
     normalized_times: np.ndarray | dict[str, np.ndarray]
     if isinstance(times, dict):
-        normalized_times = {
-            key: np.asarray(value, dtype=float) for key, value in times.items()
-        }
+        normalized_times = cast(
+            dict[str, np.ndarray],
+            {key: np.asarray(value, dtype=float) for key, value in times.items()},
+        )
     else:
         normalized_times = np.asarray(times, dtype=float)
 

--- a/src/rtichoke/performance_table_great_tables.py
+++ b/src/rtichoke/performance_table_great_tables.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import cast
 
 import numpy as np
 import polars as pl
@@ -225,11 +226,13 @@ def render_performance_table_great_tables(
                 locations=loc.body(columns="Model", rows=rows),
             )
 
-    lift_max = float(data.get_column("lift").drop_nulls().max() or 1.0)
+    lift_max = float(
+        cast(float | int, data.get_column("lift").drop_nulls().max() or 1.0)
+    )
     nb_max = 1.0
     if "net_benefit" in data.columns:
         nb = data.get_column("net_benefit").drop_nulls().abs().max()
-        nb_max = float(nb or 1.0)
+        nb_max = float(cast(float | int, nb or 1.0))
 
     for row_index in range(data.height):
         ppcr_value = data[row_index, "ppcr"]

--- a/src/rtichoke/performance_table_reactable.py
+++ b/src/rtichoke/performance_table_reactable.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any, cast
 
 import htmltools as html
 import numpy as np
@@ -141,10 +142,13 @@ def render_performance_table_reactable(
     if sort_columns:
         data = data.sort(sort_columns)
 
-    lift_max = data.get_column("lift").drop_nulls().max() or 1.0
-    nb_max = 1.0
+    lift_max = cast(float | int, data.get_column("lift").drop_nulls().max() or 1.0)
+    nb_max: float | int = 1.0
     if "net_benefit" in data.columns:
-        nb_max = data.get_column("net_benefit").drop_nulls().abs().max() or 1.0
+        nb_max = cast(
+            float | int,
+            data.get_column("net_benefit").drop_nulls().abs().max() or 1.0,
+        )
 
     models = (
         data.get_column("Model").unique(maintain_order=True).to_list()
@@ -302,6 +306,6 @@ def render_performance_table_reactable(
         compact=True,
         striped=True,
         highlight=True,
-        details=confusion_matrix,
+        details=cast(Any, confusion_matrix),
         show_sort_icon=False,
     )

--- a/src/rtichoke/processing/combinations.py
+++ b/src/rtichoke/processing/combinations.py
@@ -64,10 +64,10 @@ def create_strata_combinations(stratified_by: str, by: float, breaks) -> pl.Data
 
 
 def format_strata_column(
-    lower_bound: list[float],
-    upper_bound: list[float],
-    include_lower_bound: list[bool],
-    include_upper_bound: list[bool],
+    lower_bound: Sequence[float] | np.ndarray,
+    upper_bound: Sequence[float] | np.ndarray,
+    include_lower_bound: Sequence[bool] | np.ndarray,
+    include_upper_bound: Sequence[bool] | np.ndarray,
     decimals: int = 3,
 ) -> list[str]:
     return [


### PR DESCRIPTION
## Summary
- resolve all 11 `ty` diagnostics identified in #347
- keep the fixes behavior-preserving and focused on annotations/narrowing
- make `uv run ty check src/rtichoke` blocking in package CI

## What changed
- make intentional calibration function rebinding explicit via `setattr`
- narrow normalized time mappings for `ty`
- accept NumPy arrays in strata-formatting annotations
- narrow Polars scalar maxima before float conversion
- isolate the Reactable callable/stub mismatch with a narrow `cast`

## Validation
- `uv run ty check src/rtichoke` — passes with zero diagnostics
- `uv run ruff check .` — passes
- `uv run ruff format --check .` — passes
- `uv build` — passes
- `uv run pytest tests` — 137 passed

## Scope
Typing and developer tooling only. No runtime dependencies, public API changes, statistical changes, or intentional behavior changes.