### PR TITLE
Support Plotly 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 license = {text = "MIT"}
 requires-python = ">=3.12"
 dependencies = [
-    "plotly<6.0.0,>=5.13.1",
+    "plotly>=6.0.0,<7.0.0",
     "polarstate==0.1.8",
     "smoothstate>=0.1.1",
     "polars>=1.31.0",


### PR DESCRIPTION
## Summary
- replace the Plotly 5-only runtime constraint with `plotly>=6.0.0,<7.0.0`
- use CI to validate the existing plotting code against Plotly 6

## Scope
Dependency compatibility only. No statistical, API, or plotting behavior changes intended.

## Follow-up
Refresh `uv.lock` for the Plotly 6 resolution once the compatibility run is established.