### PR TITLE
Probe Python 3.14 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- add Python 3.14 to the package CI matrix
- use the existing lint, format, type-check, build, and test pipeline as the compatibility probe

## Scope
CI-only compatibility probe. No dependency, API, statistical, or source changes unless CI demonstrates an upstream compatibility issue.