### PR TITLE
Update pre-commit tooling versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.13
+  rev: v0.16.0
   hooks:
     # Run the linter.
     - id: ruff-check
@@ -9,7 +9,7 @@ repos:
     - id: ruff-format
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.7.12
+  rev: 0.12.1
   hooks:
     # Update the uv lockfile
     - id: uv-lock


### PR DESCRIPTION
## Summary
- update the Ruff pre-commit hook from 0.11.13 to 0.16.0
- update the uv pre-commit hook from 0.7.12 to 0.12.1
- keep this PR limited to local developer tooling

## Scope
Developer tooling only. No runtime dependencies, package API, statistics, or plotting behavior changes.

## Follow-up
Upgrade and validate Great Docs separately, then handle packaging metadata and the next package release as distinct incremental changes.