### PR TITLE
Upgrade Great Docs to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "scikit-learn>=1.6.1",
 ]
 docs = [
-    "great-docs",
+    "great-docs==0.15.0",
 ]
 
 [tool.uv.workspace]


### PR DESCRIPTION
## Summary

- pin the docs dependency to Great Docs 0.15.0
- keep the upgrade isolated from application/runtime dependencies