### PR TITLE
Prove vendored rtichoke_viz calibration rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,7 +93,7 @@ jobs:
           grep -q '.Reactable {' performance-table-reactable.html
           grep -q 'Real Positive' performance-table-reactable.html
           mv performance-table-reactable.html great-docs/_site/performance-table-reactable.html
-          cp -R examples/performance_table_reactable_files great-docs/_site/performance-table-reactable_files
+          cp -R examples/performance_table_reactable_files great-docs/_site/performance_table_reactable_files
 
       - name: Generate rtichoke_viz ROC proof
         if: github.event.action != 'closed'
@@ -101,6 +101,13 @@ jobs:
           uv run python examples/rtichoke_viz_roc.py
           mkdir -p great-docs/_site/rtichoke-viz-roc
           cp -R rtichoke_viz_roc_proof/. great-docs/_site/rtichoke-viz-roc/
+
+      - name: Generate rtichoke_viz calibration proof
+        if: github.event.action != 'closed'
+        run: |
+          uv run python examples/rtichoke_viz_calibration.py
+          mkdir -p great-docs/_site/rtichoke-viz-calibration
+          cp -R rtichoke_viz_calibration_proof/. great-docs/_site/rtichoke-viz-calibration/
 
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@v1

--- a/examples/rtichoke_viz_calibration.py
+++ b/examples/rtichoke_viz_calibration.py
@@ -1,0 +1,22 @@
+"""Generate a browser-rendered calibration proof from real rtichoke output."""
+
+from pathlib import Path
+
+import numpy as np
+
+from rtichoke._viz_browser import _write_calibration_browser_html
+from rtichoke.calibration.calibration import _create_calibration_curve_list
+
+probs = {
+    "Model A": np.array(
+        [0.03, 0.08, 0.12, 0.18, 0.25, 0.32, 0.40, 0.50, 0.62, 0.75, 0.88, 0.96]
+    )
+}
+reals = np.array([0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1])
+
+calibration_curve_list = _create_calibration_curve_list(probs, reals)
+output = _write_calibration_browser_html(
+    calibration_curve_list,
+    Path("rtichoke_viz_calibration_proof") / "index.html",
+)
+print(output)

--- a/src/rtichoke/_viz_browser.py
+++ b/src/rtichoke/_viz_browser.py
@@ -149,9 +149,9 @@ def _write_calibration_browser_html(
     output.parent.mkdir(parents=True, exist_ok=True)
     _copy_viz_assets(output.parent)
 
-    spec_json = json.dumps(_calibration_spec_from_curve_list(calibration_curve_list)).replace(
-        "</", "<\\/"
-    )
+    spec_json = json.dumps(
+        _calibration_spec_from_curve_list(calibration_curve_list)
+    ).replace("</", "<\\/")
     html = f"""<!doctype html>
 <html lang=\"en\">
 <head>

--- a/src/rtichoke/_viz_browser.py
+++ b/src/rtichoke/_viz_browser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -14,6 +15,16 @@ _REQUIRED_ROC_COLUMNS = {
     "sensitivity",
     "specificity",
 }
+
+
+def _copy_viz_assets(output_dir: Path) -> None:
+    vendor = files("rtichoke").joinpath("_vendor", "rtichoke_viz")
+    (output_dir / "rtichoke-viz.js").write_bytes(
+        vendor.joinpath("rtichoke-viz.js").read_bytes()
+    )
+    (output_dir / "rtichoke-viz.css").write_bytes(
+        vendor.joinpath("rtichoke-viz.css").read_bytes()
+    )
 
 
 def _roc_spec_from_performance_data(
@@ -52,6 +63,48 @@ def _roc_spec_from_performance_data(
     }
 
 
+def _calibration_spec_from_curve_list(
+    calibration_curve_list: dict[str, Any],
+) -> dict[str, object]:
+    """Map existing discrete calibration output to the canonical spec."""
+    rows = calibration_curve_list["deciles_dat"].select(
+        "reference_group", "x", "y", "n_reals", "n"
+    )
+    distribution_rows = calibration_curve_list["histogram_for_calibration"].select(
+        "reference_group", "mids", "counts"
+    )
+
+    return {
+        "schemaVersion": "1.0",
+        "type": "calibration",
+        "data": [
+            {
+                "model": row["reference_group"],
+                "predicted": row["x"],
+                "observed": row["y"],
+                "method": "discrete",
+                "events": row["n_reals"],
+                "total": row["n"],
+            }
+            for row in rows.to_dicts()
+        ],
+        "distribution": [
+            {
+                "model": row["reference_group"],
+                "midpoint": row["mids"],
+                "count": row["counts"],
+                "binWidth": 0.01,
+            }
+            for row in distribution_rows.to_dicts()
+        ],
+        "x": "predicted",
+        "y": "observed",
+        "xAxis": {"label": "Predicted probability", "domain": [0, 1]},
+        "yAxis": {"label": "Observed probability", "domain": [0, 1]},
+        "references": [{"type": "identity"}],
+    }
+
+
 def _write_roc_browser_html(
     performance_data: pl.DataFrame,
     output_path: str | Path,
@@ -59,12 +112,7 @@ def _write_roc_browser_html(
     """Write a standalone proof page that uses the vendored browser renderer."""
     output = Path(output_path)
     output.parent.mkdir(parents=True, exist_ok=True)
-
-    vendor = files("rtichoke").joinpath("_vendor", "rtichoke_viz")
-    js_source = vendor.joinpath("rtichoke-viz.js")
-    css_source = vendor.joinpath("rtichoke-viz.css")
-    (output.parent / "rtichoke-viz.js").write_bytes(js_source.read_bytes())
-    (output.parent / "rtichoke-viz.css").write_bytes(css_source.read_bytes())
+    _copy_viz_assets(output.parent)
 
     spec_json = json.dumps(_roc_spec_from_performance_data(performance_data)).replace(
         "</", "<\\/"
@@ -84,6 +132,41 @@ def _write_roc_browser_html(
     import {{ renderRoc }} from \"./rtichoke-viz.js\";
     const spec = JSON.parse(document.querySelector(\"#roc-spec\").textContent);
     document.querySelector(\"#roc-chart\").append(renderRoc(spec));
+  </script>
+</body>
+</html>
+"""
+    output.write_text(html, encoding="utf-8")
+    return output
+
+
+def _write_calibration_browser_html(
+    calibration_curve_list: dict[str, Any],
+    output_path: str | Path,
+) -> Path:
+    """Write a standalone discrete-calibration proof using vendored assets."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    _copy_viz_assets(output.parent)
+
+    spec_json = json.dumps(_calibration_spec_from_curve_list(calibration_curve_list)).replace(
+        "</", "<\\/"
+    )
+    html = f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>rtichoke_viz calibration vendoring proof</title>
+  <link rel=\"stylesheet\" href=\"./rtichoke-viz.css\">
+</head>
+<body>
+  <div id=\"calibration-chart\" class=\"rtichoke-viz-chart\"></div>
+  <script id=\"calibration-spec\" type=\"application/json\">{spec_json}</script>
+  <script type=\"module\">
+    import {{ renderCalibration }} from \"./rtichoke-viz.js\";
+    const spec = JSON.parse(document.querySelector(\"#calibration-spec\").textContent);
+    document.querySelector(\"#calibration-chart\").append(renderCalibration(spec));
   </script>
 </body>
 </html>

--- a/tests/test_viz_browser.py
+++ b/tests/test_viz_browser.py
@@ -3,9 +3,12 @@ from pathlib import Path
 import numpy as np
 
 from rtichoke._viz_browser import (
+    _calibration_spec_from_curve_list,
     _roc_spec_from_performance_data,
+    _write_calibration_browser_html,
     _write_roc_browser_html,
 )
+from rtichoke.calibration.calibration import _create_calibration_curve_list
 from rtichoke.performance_data.performance_data import prepare_performance_data
 
 
@@ -14,6 +17,17 @@ def _real_roc_performance_data():
         probs={"Model A": np.array([0.05, 0.10, 0.20, 0.35, 0.55, 0.70, 0.85, 0.95])},
         reals=np.array([0, 0, 0, 1, 0, 1, 1, 1]),
         by=0.1,
+    )
+
+
+def _real_calibration_curve_list():
+    return _create_calibration_curve_list(
+        probs={
+            "Model A": np.array(
+                [0.03, 0.08, 0.12, 0.18, 0.25, 0.32, 0.40, 0.50, 0.62, 0.75, 0.88, 0.96]
+            )
+        },
+        reals=np.array([0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1]),
     )
 
 
@@ -31,7 +45,21 @@ def test_real_roc_output_maps_to_canonical_spec():
     assert all(0 <= row["specificity"] <= 1 for row in spec["data"])
 
 
-def test_browser_proof_uses_vendored_assets(tmp_path: Path):
+def test_real_calibration_output_maps_to_canonical_spec():
+    spec = _calibration_spec_from_curve_list(_real_calibration_curve_list())
+
+    assert spec["schemaVersion"] == "1.0"
+    assert spec["type"] == "calibration"
+    assert spec["references"] == [{"type": "identity"}]
+    assert spec["data"]
+    assert {row["model"] for row in spec["data"]} == {"Model A"}
+    assert all(row["method"] == "discrete" for row in spec["data"])
+    assert all(0 <= row["predicted"] <= 1 for row in spec["data"])
+    assert all(0 <= row["observed"] <= 1 for row in spec["data"])
+    assert spec["distribution"]
+
+
+def test_roc_browser_proof_uses_vendored_assets(tmp_path: Path):
     output = _write_roc_browser_html(
         _real_roc_performance_data(),
         tmp_path / "index.html",
@@ -40,5 +68,18 @@ def test_browser_proof_uses_vendored_assets(tmp_path: Path):
     html = output.read_text(encoding="utf-8")
     assert 'import { renderRoc } from "./rtichoke-viz.js"' in html
     assert '"type": "roc"' in html
+    assert (tmp_path / "rtichoke-viz.js").stat().st_size > 0
+    assert (tmp_path / "rtichoke-viz.css").stat().st_size > 0
+
+
+def test_calibration_browser_proof_uses_vendored_assets(tmp_path: Path):
+    output = _write_calibration_browser_html(
+        _real_calibration_curve_list(),
+        tmp_path / "index.html",
+    )
+
+    html = output.read_text(encoding="utf-8")
+    assert 'import { renderCalibration } from "./rtichoke-viz.js"' in html
+    assert '"type": "calibration"' in html
     assert (tmp_path / "rtichoke-viz.js").stat().st_size > 0
     assert (tmp_path / "rtichoke-viz.css").stat().st_size > 0


### PR DESCRIPTION
## Goal

Extend the merged ROC vendoring proof to real `rtichoke_python` calibration output, without changing the public calibration or Plotly APIs.

## Included

- map existing discrete calibration output (`deciles_dat` + histogram rows) to the canonical `rtichoke_viz` calibration spec
- render that canonical spec with the already-vendored `renderCalibration` browser renderer
- add a small executable example using real `_create_calibration_curve_list()` output
- publish the rendered calibration proof in the PR documentation preview
- add regression tests for the canonical mapping and vendored browser assets

No statistical behavior changes. No new public API.

## Rendered preview

https://uriahf.github.io/rtichoke_python/pr-preview/pr-362/rtichoke-viz-calibration/
