### PR TITLE
Pin vendored rtichoke_viz assets to v0.1.0

### DIFF
--- a/src/rtichoke/_vendor/rtichoke_viz/VENDORED_FROM
+++ b/src/rtichoke/_vendor/rtichoke_viz/VENDORED_FROM
@@ -1,2 +1,5 @@
 repository=https://github.com/uriahf/rtichoke_viz
-commit=926ec882dfe48a13359d705817ec2d0388649253
+release=v0.1.0
+source_commit=926ec882dfe48a13359d705817ec2d0388649253
+archive=rtichoke-viz-0.1.0.tar.gz
+checksum=rtichoke-viz-0.1.0.tar.gz.sha256


### PR DESCRIPTION
## Summary

Updates the vendored `rtichoke_viz` provenance metadata to use the first immutable browser-bundle release as the canonical source.

### Change
- record `rtichoke_viz` release `v0.1.0`
- record the tagged source commit
- record the release archive and checksum sidecar names
- leave the vendored JS/CSS bytes unchanged

## Scope

Vendoring provenance only. No renderer, statistical, API, or package behavior changes.

## Follow-up

After this merges, make the analogous small change in `rtichoke` R so both packages consume the same `rtichoke_viz v0.1.0` artifact and R no longer depends on a pinned `rtichoke_python` commit.