### PR TITLE
Add shared rtichoke logo to Great Docs

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -13,6 +13,15 @@ include_in_header:
   - text: |
       <script>
       document.addEventListener('DOMContentLoaded', () => {
+        const brand = document.querySelector('a.navbar-brand');
+        if (brand && !brand.querySelector('.rtichoke-brand-logo')) {
+          const logo = document.createElement('img');
+          logo.className = 'rtichoke-brand-logo';
+          logo.src = 'https://raw.githubusercontent.com/uriahf/rtichoke/main/man/figures/logo.png';
+          logo.alt = '';
+          brand.prepend(logo);
+        }
+
         const nav = document.querySelector('nav.navbar ul.navbar-nav.me-auto');
         if (!nav || nav.querySelector('[data-rtichoke-guides-link]')) return;
 
@@ -107,4 +116,3 @@ reference:
       - create_decision_curve
       - create_decision_curve_times
       - plot_decision_curve
-

--- a/site.css
+++ b/site.css
@@ -71,6 +71,19 @@ a:focus-visible {
   color: var(--rtichoke-primary) !important;
 }
 
+.navbar-brand {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.45rem;
+}
+
+.rtichoke-brand-logo {
+  display: block;
+  height: 2.25rem;
+  object-fit: contain;
+  width: 2.25rem;
+}
+
 .navbar .nav-link:hover,
 .navbar .nav-link:focus,
 .navbar .nav-link.active {
@@ -272,4 +285,3 @@ uriahtalks-horizon-explorer .uriah-horizon-key {
     width: 720px;
   }
 }
-


### PR DESCRIPTION
Adds the shared rtichoke hex to the Great Docs navbar while keeping the documentation language-neutral. The logo is loaded from the canonical R-package logo path so both implementations use the same visual identity. This depends on uriahf/rtichoke#177 being merged first.