### PR TITLE
Add ty pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
   hooks:
     # Update the uv lockfile
     - id: uv-lock
+- repo: https://github.com/astral-sh/ty-pre-commit
+  # ty version.
+  rev: v0.0.74
+  hooks:
+    - id: ty


### PR DESCRIPTION
## Summary
- add Astral's official `ty-pre-commit` hook
- run `ty` automatically before commits so type errors are caught locally
- keep this tooling-only: no package code, lockfile, CI workflow, or Lift changes

The existing CI type check remains unchanged.