### PR TITLE
Fix direct-open browser summary reports

### DIFF
--- a/src/rtichoke/_report_browser.py
+++ b/src/rtichoke/_report_browser.py
@@ -24,6 +24,7 @@ class RtichokeBrowserReport:
             (output.parent / asset).write_bytes(vendor.joinpath(asset).read_bytes())
 
         spec_json = json.dumps(self.spec, separators=(",", ":")).replace("</", "<\\/")
+        viz_js = vendor.joinpath("rtichoke-viz.js").read_text(encoding="utf-8")
         html = f"""<!doctype html>
 <html lang="en">
 <head>
@@ -36,7 +37,7 @@ class RtichokeBrowserReport:
   <div id="rtichoke-report"></div>
   <script id="rtichoke-report-spec" type="application/json">{spec_json}</script>
   <script type="module">
-    import {{ renderReport }} from "./rtichoke-viz.js";
+{viz_js}
     const spec = JSON.parse(
       document.querySelector("#rtichoke-report-spec").textContent
     );

--- a/tests/test_calibration_v2.py
+++ b/tests/test_calibration_v2.py
@@ -273,6 +273,7 @@ def test_real_performance_table_roc_calibration_report_uses_shared_renderer(tmp_
         tmp_path / "report.html"
     )
     html = output.read_text(encoding="utf-8")
+    viz_js = (tmp_path / "rtichoke-viz.js").read_text(encoding="utf-8")
 
     assert [component["id"] for component in report["components"]] == [
         "performance-table",
@@ -281,11 +282,9 @@ def test_real_performance_table_roc_calibration_report_uses_shared_renderer(tmp_
     ]
     assert report["components"][2]["spec"] is calibration
     assert _embedded_report(html) == report
-    assert 'import { renderReport } from "./rtichoke-viz.js";' in html
+    assert 'import { renderReport } from "./rtichoke-viz.js";' not in html
+    assert viz_js in html
     assert "append(renderReport(spec))" in html
-    assert "renderCalibrationV2" not in html
-    assert "renderRocV2" not in html
-    assert "renderPerformanceTable" not in html
 
 
 def test_duplicate_evaluation_ids_remain_component_local_in_real_report():

--- a/tests/test_report_browser.py
+++ b/tests/test_report_browser.py
@@ -49,12 +49,11 @@ def test_browser_report_uses_real_producers_and_only_shared_render_report(tmp_pa
         tmp_path / "report.html"
     )
     html = output.read_text(encoding="utf-8")
+    viz_js = (tmp_path / "rtichoke-viz.js").read_text(encoding="utf-8")
 
-    assert 'import { renderReport } from "./rtichoke-viz.js";' in html
+    assert 'import { renderReport } from "./rtichoke-viz.js";' not in html
+    assert viz_js in html
     assert "append(renderReport(spec))" in html
-    assert "renderRocV2" not in html
-    assert "renderPerformanceTable" not in html
-    assert "renderGainsV2" not in html
     assert _embedded_report(html) == report
     assert [component["id"] for component in report["components"]] == [
         "performance-table",

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -100,6 +100,7 @@ def _serve(directory: Path) -> Iterator[str]:
 
 def _assert_report_rendered(browser: subprocess.CompletedProcess[str]) -> None:
     assert browser.returncode == 0, browser.stderr
+    assert "INFO:CONSOLE" not in browser.stderr, browser.stderr
     rendered = _rendered_report_html(browser.stdout)
     assert "Performance" in rendered, browser.stderr
     assert "ROC" in rendered

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -1,8 +1,12 @@
 import json
 import shutil
 import subprocess
+from contextlib import contextmanager
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, cast
+from threading import Thread
+from typing import Any, Iterator, cast
 
 import numpy as np
 import pytest
@@ -54,7 +58,7 @@ def _chrome_executable() -> str:
     pytest.skip("headless Chrome/Chromium is not available")
 
 
-def _dump_dom(path: Path) -> subprocess.CompletedProcess[str]:
+def _dump_dom(url: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             _chrome_executable(),
@@ -64,13 +68,45 @@ def _dump_dom(path: Path) -> subprocess.CompletedProcess[str]:
             "--enable-logging=stderr",
             "--log-level=0",
             "--dump-dom",
-            path.resolve().as_uri(),
+            url,
         ],
         check=False,
         capture_output=True,
         text=True,
         timeout=30,
     )
+
+
+def _rendered_report_html(dom: str) -> str:
+    marker = '<div id="rtichoke-report">'
+    start = dom.index(marker) + len(marker)
+    end = dom.index('<script id="rtichoke-report-spec"', start)
+    return dom[start:end]
+
+
+@contextmanager
+def _serve(directory: Path) -> Iterator[str]:
+    handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def _assert_report_rendered(browser: subprocess.CompletedProcess[str]) -> None:
+    assert browser.returncode == 0, browser.stderr
+    rendered = _rendered_report_html(browser.stdout)
+    assert rendered.strip(), browser.stderr
+    assert "Performance" in rendered
+    assert "ROC" in rendered
+    assert "Calibration" in rendered
+    assert "<table" in rendered
+    assert rendered.count("<svg") >= 2
 
 
 def test_default_summary_report_keeps_historical_r_backend(monkeypatch, capsys):
@@ -159,13 +195,25 @@ def test_browser_summary_report_executes_when_opened_directly(tmp_path):
     )
     assert isinstance(output, Path)
 
-    browser = _dump_dom(output)
+    browser = _dump_dom(output.resolve().as_uri())
 
-    assert browser.returncode == 0, browser.stderr
-    assert 'id="rtichoke-report"></div>' not in browser.stdout
-    assert "Performance" in browser.stdout
-    assert "ROC" in browser.stdout
-    assert "Calibration" in browser.stdout
+    _assert_report_rendered(browser)
+
+
+def test_browser_summary_report_executes_over_localhost(tmp_path):
+    probs, reals = _inputs()
+    output = create_summary_report(
+        probs,
+        reals,
+        renderer="browser",
+        output_file=tmp_path / "browser_report.html",
+    )
+    assert isinstance(output, Path)
+
+    with _serve(output.parent) as base_url:
+        browser = _dump_dom(f"{base_url}/{output.name}")
+
+    _assert_report_rendered(browser)
 
 
 def test_browser_summary_report_preserves_component_local_identity(tmp_path):

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -1,8 +1,11 @@
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
+import pytest
 
 from rtichoke.summary_report import summary_report as summary_report_module
 from rtichoke.summary_report.summary_report import create_summary_report
@@ -36,6 +39,33 @@ def _embedded_report(html: str) -> dict[str, Any]:
     start = html.index(">", start) + 1
     end = html.index("</script>", start)
     return cast(dict[str, Any], json.loads(html[start:end]))
+
+
+def _chrome_executable() -> str:
+    for candidate in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+        executable = shutil.which(candidate)
+        if executable is not None:
+            return executable
+    pytest.skip("headless Chrome/Chromium is not available")
+
+
+def _dump_dom(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            _chrome_executable(),
+            "--headless=new",
+            "--no-sandbox",
+            "--disable-gpu",
+            "--enable-logging=stderr",
+            "--log-level=0",
+            "--dump-dom",
+            path.resolve().as_uri(),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
 
 def test_default_summary_report_keeps_historical_r_backend(monkeypatch, capsys):
@@ -112,6 +142,25 @@ def test_browser_summary_report_is_opt_in_and_uses_real_canonical_components(
     assert "renderPerformanceTable" not in html
     assert "renderRocV2" not in html
     assert "renderCalibrationV2" not in html
+
+
+def test_browser_summary_report_executes_when_opened_directly(tmp_path):
+    probs, reals = _inputs()
+    output = create_summary_report(
+        probs,
+        reals,
+        renderer="browser",
+        output_file=tmp_path / "browser_report.html",
+    )
+    assert isinstance(output, Path)
+
+    browser = _dump_dom(output)
+
+    assert browser.returncode == 0, browser.stderr
+    assert 'id="rtichoke-report"></div>' not in browser.stdout
+    assert "Performance" in browser.stdout
+    assert "ROC" in browser.stdout
+    assert "Calibration" in browser.stdout
 
 
 def test_browser_summary_report_preserves_component_local_identity(tmp_path):

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -101,8 +101,7 @@ def _serve(directory: Path) -> Iterator[str]:
 def _assert_report_rendered(browser: subprocess.CompletedProcess[str]) -> None:
     assert browser.returncode == 0, browser.stderr
     rendered = _rendered_report_html(browser.stdout)
-    assert rendered.strip(), browser.stderr
-    assert "Performance" in rendered
+    assert "Performance" in rendered, browser.stderr
     assert "ROC" in rendered
     assert "Calibration" in rendered
     assert "<table" in rendered

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -42,7 +42,12 @@ def _embedded_report(html: str) -> dict[str, Any]:
 
 
 def _chrome_executable() -> str:
-    for candidate in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+    for candidate in (
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
         executable = shutil.which(candidate)
         if executable is not None:
             return executable

--- a/tests/test_summary_report_browser.py
+++ b/tests/test_summary_report_browser.py
@@ -160,7 +160,8 @@ def test_browser_summary_report_is_opt_in_and_uses_real_canonical_components(
 
     assert result == output
     assert output.exists()
-    assert (tmp_path / "rtichoke-viz.js").exists()
+    viz_js_path = tmp_path / "rtichoke-viz.js"
+    assert viz_js_path.exists()
     assert (tmp_path / "rtichoke-viz.css").exists()
 
     html = output.read_text(encoding="utf-8")
@@ -177,11 +178,9 @@ def test_browser_summary_report_is_opt_in_and_uses_real_canonical_components(
     ]
     assert report["components"][1]["spec"]["schemaVersion"] == "2.0"
     assert report["components"][2]["spec"]["schemaVersion"] == "2.0"
-    assert 'import { renderReport } from "./rtichoke-viz.js";' in html
+    assert 'import { renderReport } from "./rtichoke-viz.js";' not in html
+    assert viz_js_path.read_text(encoding="utf-8") in html
     assert "append(renderReport(spec))" in html
-    assert "renderPerformanceTable" not in html
-    assert "renderRocV2" not in html
-    assert "renderCalibrationV2" not in html
 
 
 def test_browser_summary_report_executes_when_opened_directly(tmp_path):


### PR DESCRIPTION
## Summary

Fix the direct-open offline browser summary report introduced in #387 without changing statistics, ReportSpec, component identity semantics, or `rtichoke_viz` itself.

## Reproduction and root cause

Using the real public call and real production PerformanceTable + ROC-v2 + calibration-v2 producers, the pre-fix artifact contained a valid canonical ReportSpec and rendered correctly when the same directory was served over localhost HTTP.

Direct `file://` opening failed in headless Chrome with the report container left empty and this console error:

> Access to script at 'file:///.../rtichoke-viz.js' from origin 'null' has been blocked by CORS policy: Cross origin requests are only supported for protocol schemes: chrome, chrome-extension, chrome-untrusted, data, http, https, isolated-app.

Pre-fix executable regression result: `1 failed, 250 passed`; the only failure was direct `file://`, while localhost passed.

This establishes the defect as the external ES-module loading strategy, not ReportSpec, `renderReport()`, CSS, or the canonical component producers.

## Fix

`RtichokeBrowserReport.write_html()` now embeds the exact vendored immutable v0.5.0 `rtichoke-viz.js` bundle inside the generated module script and still delegates report composition to the shared `renderReport(spec)` implementation. It retains the existing sibling JS/CSS output files for output compatibility.

No renderer logic is reimplemented in Python, no component dispatcher is added, and no vendored `rtichoke_viz` bytes are modified. A new `rtichoke_viz` release is not required because the existing compiled v0.5.0 bundle is self-contained and works when loaded inline.

## Regression proof

The new browser test crosses the boundary #387 missed:

1. calls real public `create_summary_report(..., renderer="browser")`;
2. opens the generated HTML directly via `file://` in headless Chrome;
3. fails on browser console errors;
4. asserts `#rtichoke-report` contains rendered output;
5. asserts PerformanceTable title + `<table>`;
6. asserts ROC and Calibration titles plus rendered SVG charts;
7. separately serves the same directory over localhost and verifies it too.

Post-fix `tests/test_summary_report_browser.py`: all 6 tests pass inside the full suite.

## Compatibility

- default `renderer="r"`: unchanged
- historical R backend / Quarto: unchanged
- Plotly / Matplotlib / tables / standalone browser charts: untouched
- output path/return behavior: unchanged
- sibling `rtichoke-viz.js` and `rtichoke-viz.css`: still written
- component IDs / series IDs / component-local evaluation IDs: unchanged

## Checks

Final Python-package CI matrix is green on Python 3.12, 3.13, and 3.14:

- Ruff lint: pass
- Ruff format check: pass
- `ty`: pass
- package build: pass
- vendored browser assets in wheel: pass
- full pytest: `251 passed` (3.12 shown; matrix jobs all green)

Documentation preview is tracked by the normal PR workflow.