### PR TITLE
Add static Precision-Recall browser rendering

### DIFF
--- a/src/rtichoke/_viz_spec_v2.py
+++ b/src/rtichoke/_viz_spec_v2.py
@@ -19,6 +19,14 @@ _REQUIRED_ROC_COLUMNS = {
     "sensitivity",
     "specificity",
 }
+_REQUIRED_PRECISION_RECALL_COLUMNS = {
+    "reference_group",
+    "chosen_cutoff",
+    "sensitivity",
+    "ppv",
+    "real_positives",
+    "n",
+}
 _REQUIRED_GAINS_COLUMNS = {
     "reference_group",
     "chosen_cutoff",
@@ -47,6 +55,33 @@ def _roc_v2_spec_from_performance_data(
         evaluation_metadata,
         chart_type="roc",
     )
+
+
+def _precision_recall_v2_spec_from_performance_data(
+    performance_data: pl.DataFrame,
+    evaluation_metadata: Mapping[str, _EvaluationMetadata],
+) -> dict[str, object]:
+    """Build canonical static Precision-Recall from production quantities."""
+    spec = _curve_v2_spec_from_performance_data(
+        performance_data,
+        evaluation_metadata,
+        chart_type="precision_recall",
+    )
+    prevalence = _gains_population_prevalence(performance_data, evaluation_metadata)
+    populations = list(
+        dict.fromkeys(metadata.population for metadata in evaluation_metadata.values())
+    )
+    spec["references"] = [
+        {
+            "type": "horizontal",
+            "scope": "population",
+            "population": population,
+            "value": prevalence[population],
+            "label": "Prevalence",
+        }
+        for population in populations
+    ]
+    return spec
 
 
 def _gains_v2_spec_from_performance_data(
@@ -512,6 +547,9 @@ def _curve_v2_spec_from_performance_data(
     if chart_type == "roc":
         required = _REQUIRED_ROC_COLUMNS
         selected = ["reference_group", "chosen_cutoff", "sensitivity", "specificity"]
+    elif chart_type == "precision_recall":
+        required = _REQUIRED_PRECISION_RECALL_COLUMNS
+        selected = ["reference_group", "chosen_cutoff", "sensitivity", "ppv"]
     elif chart_type == "gains":
         required = _REQUIRED_GAINS_COLUMNS
         selected = ["reference_group", "chosen_cutoff", "sensitivity", "ppcr"]
@@ -587,6 +625,9 @@ def _curve_v2_spec_from_performance_data(
         if chart_type == "roc":
             datum["sensitivity"] = row["sensitivity"]
             datum["specificity"] = row["specificity"]
+        elif chart_type == "precision_recall":
+            datum["sensitivity"] = row["sensitivity"]
+            datum["ppv"] = row["ppv"]
         elif chart_type == "gains":
             datum["sensitivity"] = row["sensitivity"]
             datum["ppcr"] = row["ppcr"]
@@ -607,6 +648,20 @@ def _curve_v2_spec_from_performance_data(
             "xAxis": {"label": "1 - Specificity", "domain": [0, 1]},
             "yAxis": {"label": "Sensitivity", "domain": [0, 1]},
             "references": [{"type": "identity", "scope": "global"}],
+        }
+
+    if chart_type == "precision_recall":
+        return {
+            "schemaVersion": "2.0",
+            "type": "precision_recall",
+            "evaluations": evaluations,
+            "series": series,
+            "data": data,
+            "x": "sensitivity",
+            "y": "ppv",
+            "xAxis": {"label": "Sensitivity", "domain": [0, 1]},
+            "yAxis": {"label": "Positive Predictive Value", "domain": [0, 1]},
+            "references": [],
         }
 
     if chart_type == "gains":

--- a/src/rtichoke/_viz_spec_v2.py
+++ b/src/rtichoke/_viz_spec_v2.py
@@ -62,8 +62,13 @@ def _precision_recall_v2_spec_from_performance_data(
     evaluation_metadata: Mapping[str, _EvaluationMetadata],
 ) -> dict[str, object]:
     """Build canonical static Precision-Recall from production quantities."""
+    finite_rows = performance_data.filter(
+        pl.col("chosen_cutoff").is_finite()
+        & pl.col("sensitivity").is_finite()
+        & pl.col("ppv").is_finite()
+    )
     spec = _curve_v2_spec_from_performance_data(
-        performance_data,
+        finite_rows,
         evaluation_metadata,
         chart_type="precision_recall",
     )

--- a/src/rtichoke/discrimination/precision_recall.py
+++ b/src/rtichoke/discrimination/precision_recall.py
@@ -42,7 +42,9 @@ def _performance_data_evaluation_metadata(
 ) -> dict[str, _EvaluationMetadata]:
     """Treat pre-computed groups as populations when model identity is unknown."""
     groups = list(
-        dict.fromkeys(str(value) for value in performance_data["reference_group"].to_list())
+        dict.fromkeys(
+            str(value) for value in performance_data["reference_group"].to_list()
+        )
     )
     return {
         group: _EvaluationMetadata(

--- a/src/rtichoke/discrimination/precision_recall.py
+++ b/src/rtichoke/discrimination/precision_recall.py
@@ -2,7 +2,7 @@
 A module for Precision-Recall Curves using Plotly helpers
 """
 
-from typing import Dict, List, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
 from plotly.graph_objs._figure import Figure
 from rtichoke.processing.binary_color_values import _apply_color_values_binary
 from rtichoke.processing.plotly_helper_functions import (
@@ -14,6 +14,45 @@ from rtichoke.processing.time_reference_lines import (
 )
 import numpy as np
 import polars as pl
+
+from rtichoke._renderers import RtichokeBrowserChart, _validate_renderer
+from rtichoke._viz_spec_v2 import _precision_recall_v2_spec_from_performance_data
+from rtichoke.performance_data.performance_data import prepare_performance_data
+from rtichoke.processing.evaluation_semantics import (
+    _EvaluationMetadata,
+    _build_evaluation_metadata,
+)
+
+
+def _precision_recall_browser_chart(
+    performance_data: pl.DataFrame,
+    evaluation_metadata: dict[str, _EvaluationMetadata],
+    *,
+    size: int,
+) -> RtichokeBrowserChart:
+    spec = _precision_recall_v2_spec_from_performance_data(
+        performance_data,
+        evaluation_metadata,
+    )
+    return RtichokeBrowserChart(spec=spec, size=size)
+
+
+def _performance_data_evaluation_metadata(
+    performance_data: pl.DataFrame,
+) -> dict[str, _EvaluationMetadata]:
+    """Treat pre-computed groups as populations when model identity is unknown."""
+    groups = list(
+        dict.fromkeys(str(value) for value in performance_data["reference_group"].to_list())
+    )
+    return {
+        group: _EvaluationMetadata(
+            reference_group=group,
+            evaluation=group,
+            model=None,
+            population=group,
+        )
+        for group in groups
+    }
 
 
 def create_precision_recall_curve(
@@ -44,7 +83,8 @@ def create_precision_recall_curve(
         "#D1603D",
         "#585123",
     ],
-) -> Figure:
+    renderer: str = "plotly",
+) -> Any:
     """Creates a Precision-Recall curve.
 
     This function generates a Precision-Recall curve, which is a common
@@ -67,13 +107,36 @@ def create_precision_recall_curve(
     size : int, optional
         The width and height of the plot in pixels. Defaults to 600.
     color_values : List[str], optional
-        A list of hex color strings for the plot lines.
+        A list of hex color strings for the Plotly lines.
+    renderer : {"plotly", "browser", "rtichoke_viz"}, optional
+        Rendering backend. ``"plotly"`` remains the default. ``"browser"`` and
+        its ``"rtichoke_viz"`` alias return a canonical offline browser chart.
 
     Returns
     -------
-    Figure
-        A Plotly ``Figure`` object representing the Precision-Recall curve.
+    Figure or RtichokeBrowserChart
+        A Plotly ``Figure`` or canonical offline browser chart.
     """
+    selected_renderer = _validate_renderer(renderer)
+    if selected_renderer != "plotly":
+        if selected_renderer == "matplotlib":
+            raise ValueError(
+                "Precision-Recall supports 'plotly', 'browser', and 'rtichoke_viz' "
+                "renderers."
+            )
+        performance_data = prepare_performance_data(
+            probs=probs,
+            reals=reals,
+            by=by,
+            stratified_by=stratified_by,
+        )
+        evaluation_metadata = _build_evaluation_metadata(probs, reals, np.array([]))
+        return _precision_recall_browser_chart(
+            performance_data,
+            evaluation_metadata,
+            size=size,
+        )
+
     fig = _create_rtichoke_plotly_curve_binary(
         probs,
         reals,
@@ -90,28 +153,48 @@ def plot_precision_recall_curve(
     performance_data: pl.DataFrame,
     stratified_by: Sequence[str] = ["probability_threshold"],
     size: int = 600,
-) -> Figure:
+    renderer: str = "plotly",
+) -> Any:
     """Plots a Precision-Recall curve from pre-computed performance data.
 
     This function is useful when you have already computed the performance
-    metrics and want to generate a Precision-Recall plot directly.
+    metrics and want to generate a Precision-Recall plot directly. Pre-computed
+    data does not encode separate model identity, so canonical browser rendering
+    treats each ``reference_group`` as a population with unknown model identity.
 
     Parameters
     ----------
     performance_data : pl.DataFrame
         A Polars DataFrame with the necessary performance metrics, including
-        precision (ppv) and recall (tpr), along with any stratification variables.
+        precision (ppv) and recall (sensitivity), along with the production
+        prevalence quantities ``real_positives`` and ``n``.
     stratified_by : Sequence[str], optional
         The columns in `performance_data` used for stratification. Defaults to
         ``["probability_threshold"]``.
     size : int, optional
         The width and height of the plot in pixels. Defaults to 600.
+    renderer : {"plotly", "browser", "rtichoke_viz"}, optional
+        Rendering backend. ``"plotly"`` remains the default.
 
     Returns
     -------
-    Figure
-        A Plotly ``Figure`` object representing the Precision-Recall curve.
+    Figure or RtichokeBrowserChart
+        A Plotly ``Figure`` or canonical offline browser chart.
     """
+    selected_renderer = _validate_renderer(renderer)
+    if selected_renderer != "plotly":
+        if selected_renderer == "matplotlib":
+            raise ValueError(
+                "Precision-Recall supports 'plotly', 'browser', and 'rtichoke_viz' "
+                "renderers."
+            )
+        evaluation_metadata = _performance_data_evaluation_metadata(performance_data)
+        return _precision_recall_browser_chart(
+            performance_data,
+            evaluation_metadata,
+            size=size,
+        )
+
     fig = _plot_rtichoke_curve_binary(
         performance_data,
         size=size,

--- a/tests/test_precision_recall_v2.py
+++ b/tests/test_precision_recall_v2.py
@@ -1,0 +1,336 @@
+import inspect
+import shutil
+import subprocess
+from contextlib import contextmanager
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Iterator
+
+import numpy as np
+import plotly.graph_objects as go
+import plotly.io as pio
+import pytest
+
+from rtichoke import (
+    create_precision_recall_curve,
+    create_precision_recall_curve_times,
+    plot_precision_recall_curve,
+    prepare_performance_data,
+)
+from rtichoke._renderers import RtichokeBrowserChart
+from rtichoke._viz_spec_v2 import _precision_recall_v2_spec_from_performance_data
+from rtichoke.processing.evaluation_semantics import _build_evaluation_metadata
+
+
+PROBS_A = np.array([0.05, 0.15, 0.35, 0.55, 0.75, 0.95, 0.25, 0.85])
+PROBS_B = np.array([0.10, 0.20, 0.40, 0.60, 0.70, 0.90, 0.30, 0.80])
+REALS_EQUAL = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+REALS_LOW = np.array([0, 0, 0, 0, 0, 0, 1, 1])
+REALS_HIGH = np.array([0, 0, 1, 1, 1, 1, 1, 1])
+
+
+def _spec(probs, reals, *, by=0.25):
+    performance_data = prepare_performance_data(probs=probs, reals=reals, by=by)
+    metadata = _build_evaluation_metadata(probs, reals, np.array([]))
+    return (
+        performance_data,
+        _precision_recall_v2_spec_from_performance_data(performance_data, metadata),
+    )
+
+
+def test_one_model_spec_is_pure_pass_through_with_deterministic_ids():
+    performance_data, spec = _spec({"Model A": PROBS_A}, REALS_EQUAL)
+
+    assert spec["schemaVersion"] == "2.0"
+    assert spec["type"] == "precision_recall"
+    assert spec["x"] == "sensitivity"
+    assert spec["y"] == "ppv"
+    assert spec["evaluations"] == [
+        {
+            "id": "evaluation-1",
+            "model": "Model A",
+            "population": "__shared_population__",
+        }
+    ]
+    assert spec["series"] == [
+        {
+            "id": "series-1",
+            "evaluationId": "evaluation-1",
+            "display": {
+                "label": "Model A",
+                "group": "Model A",
+                "role": "model",
+            },
+        }
+    ]
+
+    expected_rows = performance_data.select(
+        "chosen_cutoff", "sensitivity", "ppv"
+    ).to_dicts()
+    assert spec["data"] == [
+        {
+            "seriesId": "series-1",
+            "cutoff": row["chosen_cutoff"],
+            "sensitivity": row["sensitivity"],
+            "ppv": row["ppv"],
+        }
+        for row in expected_rows
+    ]
+    assert spec["references"] == [
+        {
+            "type": "horizontal",
+            "scope": "population",
+            "population": "__shared_population__",
+            "value": 0.5,
+            "label": "Prevalence",
+        }
+    ]
+
+
+def test_multiple_models_share_one_population_and_one_prevalence_reference():
+    _, spec = _spec(
+        {"Model A": PROBS_A, "Model B": PROBS_B},
+        REALS_EQUAL,
+    )
+
+    assert [evaluation["id"] for evaluation in spec["evaluations"]] == [
+        "evaluation-1",
+        "evaluation-2",
+    ]
+    assert [evaluation["model"] for evaluation in spec["evaluations"]] == [
+        "Model A",
+        "Model B",
+    ]
+    assert {evaluation["population"] for evaluation in spec["evaluations"]} == {
+        "__shared_population__"
+    }
+    assert [series["id"] for series in spec["series"]] == ["series-1", "series-2"]
+    assert [series["display"] for series in spec["series"]] == [
+        {"label": "Model A", "group": "Model A", "role": "model"},
+        {"label": "Model B", "group": "Model B", "role": "model"},
+    ]
+    assert spec["references"] == [
+        {
+            "type": "horizontal",
+            "scope": "population",
+            "population": "__shared_population__",
+            "value": 0.5,
+            "label": "Prevalence",
+        }
+    ]
+
+
+def test_multiple_populations_keep_model_unknown_and_own_references():
+    _, spec = _spec(
+        {"Population low": PROBS_A, "Population high": PROBS_B},
+        {"Population low": REALS_LOW, "Population high": REALS_HIGH},
+    )
+
+    assert spec["evaluations"] == [
+        {"id": "evaluation-1", "population": "Population low"},
+        {"id": "evaluation-2", "population": "Population high"},
+    ]
+    assert [series["display"] for series in spec["series"]] == [
+        {"label": "Population low", "group": "Population low", "role": "population"},
+        {
+            "label": "Population high",
+            "group": "Population high",
+            "role": "population",
+        },
+    ]
+    assert spec["references"] == [
+        {
+            "type": "horizontal",
+            "scope": "population",
+            "population": "Population low",
+            "value": 0.25,
+            "label": "Prevalence",
+        },
+        {
+            "type": "horizontal",
+            "scope": "population",
+            "population": "Population high",
+            "value": 0.75,
+            "label": "Prevalence",
+        },
+    ]
+
+
+def test_equal_prevalence_populations_remain_distinct_reference_owners():
+    _, spec = _spec(
+        {"Population A": PROBS_A, "Population B": PROBS_B},
+        {"Population A": REALS_EQUAL, "Population B": REALS_EQUAL.copy()},
+    )
+
+    assert len(spec["references"]) == 2
+    assert [reference["population"] for reference in spec["references"]] == [
+        "Population A",
+        "Population B",
+    ]
+    assert [reference["value"] for reference in spec["references"]] == [0.5, 0.5]
+
+
+def test_ordinal_ids_do_not_depend_on_labels():
+    _, first = _spec({"Alpha": PROBS_A, "Beta": PROBS_B}, REALS_EQUAL)
+    _, second = _spec({"Renamed 1": PROBS_A, "Renamed 2": PROBS_B}, REALS_EQUAL)
+
+    assert [evaluation["id"] for evaluation in first["evaluations"]] == [
+        "evaluation-1",
+        "evaluation-2",
+    ]
+    assert [evaluation["id"] for evaluation in second["evaluations"]] == [
+        "evaluation-1",
+        "evaluation-2",
+    ]
+    assert [series["id"] for series in first["series"]] == ["series-1", "series-2"]
+    assert [series["id"] for series in second["series"]] == ["series-1", "series-2"]
+
+
+def test_public_browser_renderer_returns_existing_browser_chart_and_dispatch(tmp_path: Path):
+    chart = create_precision_recall_curve(
+        {"Model A": PROBS_A},
+        REALS_EQUAL,
+        by=0.25,
+        renderer="browser",
+    )
+
+    assert isinstance(chart, RtichokeBrowserChart)
+    assert chart.spec["type"] == "precision_recall"
+    output = chart.write_html(tmp_path / "precision-recall.html")
+    html = output.read_text(encoding="utf-8")
+    assert 'import { renderPrecisionRecallV2 } from "./rtichoke-viz.js"' in html
+    assert '"type":"precision_recall"' in html
+    assert (tmp_path / "rtichoke-viz.js").is_file()
+    assert (tmp_path / "rtichoke-viz.css").is_file()
+
+
+@pytest.mark.parametrize("renderer", ["browser", "rtichoke_viz"])
+def test_browser_aliases_use_same_static_canonical_contract(renderer: str):
+    chart = create_precision_recall_curve(
+        {"Model A": PROBS_A},
+        REALS_EQUAL,
+        by=0.25,
+        renderer=renderer,
+    )
+    assert isinstance(chart, RtichokeBrowserChart)
+    assert chart.spec["schemaVersion"] == "2.0"
+    assert chart.spec["type"] == "precision_recall"
+
+
+def test_precomputed_browser_api_uses_population_semantics_when_model_is_unknown():
+    performance_data = prepare_performance_data(
+        probs={"Group A": PROBS_A, "Group B": PROBS_B},
+        reals=REALS_EQUAL,
+        by=0.25,
+    )
+
+    chart = plot_precision_recall_curve(performance_data, renderer="browser")
+
+    assert isinstance(chart, RtichokeBrowserChart)
+    assert chart.spec["evaluations"] == [
+        {"id": "evaluation-1", "population": "Group A"},
+        {"id": "evaluation-2", "population": "Group B"},
+    ]
+    assert [series["display"]["role"] for series in chart.spec["series"]] == [
+        "population",
+        "population",
+    ]
+
+
+def test_default_and_explicit_plotly_behavior_are_unchanged():
+    probs = {"Model A": PROBS_A, "Model B": PROBS_B}
+
+    default = create_precision_recall_curve(probs, REALS_EQUAL, by=0.25)
+    explicit = create_precision_recall_curve(
+        probs,
+        REALS_EQUAL,
+        by=0.25,
+        renderer="plotly",
+    )
+
+    assert isinstance(default, go.Figure)
+    assert pio.to_json(default) == pio.to_json(explicit)
+
+    performance_data = prepare_performance_data(probs=probs, reals=REALS_EQUAL, by=0.25)
+    default_plot = plot_precision_recall_curve(performance_data)
+    explicit_plot = plot_precision_recall_curve(performance_data, renderer="plotly")
+    assert pio.to_json(default_plot) == pio.to_json(explicit_plot)
+
+
+def test_time_dependent_precision_recall_api_does_not_gain_renderer_selection():
+    parameters = inspect.signature(create_precision_recall_curve_times).parameters
+    assert "renderer" not in parameters
+
+
+def test_vendored_v050_contains_static_precision_recall_contract_and_export():
+    vendor = Path(__file__).parents[1] / "src" / "rtichoke" / "_vendor" / "rtichoke_viz"
+    bundle = (vendor / "rtichoke-viz.js").read_text(encoding="utf-8")
+    schema = (vendor / "rtichoke-viz-v2.schema.json").read_text(encoding="utf-8")
+
+    assert "PrecisionRecallV2SpecSchema" in bundle
+    assert "renderPrecisionRecallV2" in bundle
+    assert '"const": "precision_recall"' in schema
+    assert '"const": "population"' in schema
+    assert '"const": "horizontal"' in schema
+
+
+def _chrome_executable() -> str:
+    for candidate in (
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
+        executable = shutil.which(candidate)
+        if executable is not None:
+            return executable
+    pytest.skip("headless Chrome/Chromium is not available")
+
+
+@contextmanager
+def _serve(directory: Path) -> Iterator[str]:
+    handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def test_public_browser_chart_executes_to_svg_when_chrome_is_available(tmp_path: Path):
+    chart = create_precision_recall_curve(
+        {"Model A": PROBS_A},
+        REALS_EQUAL,
+        by=0.25,
+        renderer="browser",
+    )
+    chart.write_html(tmp_path / "precision-recall.html")
+
+    with _serve(tmp_path) as base_url:
+        result = subprocess.run(
+            [
+                _chrome_executable(),
+                "--headless=new",
+                "--no-sandbox",
+                "--disable-gpu",
+                "--enable-logging=stderr",
+                "--log-level=0",
+                "--dump-dom",
+                f"{base_url}/precision-recall.html",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert "INFO:CONSOLE" not in result.stderr, result.stderr
+    assert "<svg" in result.stdout
+    assert "rtichoke-viz-chart" in result.stdout

--- a/tests/test_precision_recall_v2.py
+++ b/tests/test_precision_recall_v2.py
@@ -133,7 +133,11 @@ def test_multiple_populations_keep_model_unknown_and_own_references():
         {"id": "evaluation-2", "population": "Population high"},
     ]
     assert [series["display"] for series in spec["series"]] == [
-        {"label": "Population low", "group": "Population low", "role": "population"},
+        {
+            "label": "Population low",
+            "group": "Population low",
+            "role": "population",
+        },
         {
             "label": "Population high",
             "group": "Population high",
@@ -188,7 +192,9 @@ def test_ordinal_ids_do_not_depend_on_labels():
     assert [series["id"] for series in second["series"]] == ["series-1", "series-2"]
 
 
-def test_public_browser_renderer_returns_existing_browser_chart_and_dispatch(tmp_path: Path):
+def test_public_browser_renderer_returns_existing_browser_chart_and_dispatch(
+    tmp_path: Path,
+):
     chart = create_precision_recall_curve(
         {"Model A": PROBS_A},
         REALS_EQUAL,
@@ -253,7 +259,11 @@ def test_default_and_explicit_plotly_behavior_are_unchanged():
     assert isinstance(default, go.Figure)
     assert pio.to_json(default) == pio.to_json(explicit)
 
-    performance_data = prepare_performance_data(probs=probs, reals=REALS_EQUAL, by=0.25)
+    performance_data = prepare_performance_data(
+        probs=probs,
+        reals=REALS_EQUAL,
+        by=0.25,
+    )
     default_plot = plot_precision_recall_curve(performance_data)
     explicit_plot = plot_precision_recall_curve(performance_data, renderer="plotly")
     assert pio.to_json(default_plot) == pio.to_json(explicit_plot)
@@ -265,7 +275,13 @@ def test_time_dependent_precision_recall_api_does_not_gain_renderer_selection():
 
 
 def test_vendored_v050_contains_static_precision_recall_contract_and_export():
-    vendor = Path(__file__).parents[1] / "src" / "rtichoke" / "_vendor" / "rtichoke_viz"
+    vendor = (
+        Path(__file__).parents[1]
+        / "src"
+        / "rtichoke"
+        / "_vendor"
+        / "rtichoke_viz"
+    )
     bundle = (vendor / "rtichoke-viz.js").read_text(encoding="utf-8")
     schema = (vendor / "rtichoke-viz-v2.schema.json").read_text(encoding="utf-8")
 
@@ -303,7 +319,9 @@ def _serve(directory: Path) -> Iterator[str]:
         server.server_close()
 
 
-def test_public_browser_chart_executes_to_svg_when_chrome_is_available(tmp_path: Path):
+def test_public_browser_chart_executes_to_svg_when_chrome_is_available(
+    tmp_path: Path,
+):
     chart = create_precision_recall_curve(
         {"Model A": PROBS_A},
         REALS_EQUAL,

--- a/tests/test_precision_recall_v2.py
+++ b/tests/test_precision_recall_v2.py
@@ -133,11 +133,7 @@ def test_multiple_populations_keep_model_unknown_and_own_references():
         {"id": "evaluation-2", "population": "Population high"},
     ]
     assert [series["display"] for series in spec["series"]] == [
-        {
-            "label": "Population low",
-            "group": "Population low",
-            "role": "population",
-        },
+        {"label": "Population low", "group": "Population low", "role": "population"},
         {
             "label": "Population high",
             "group": "Population high",
@@ -259,11 +255,7 @@ def test_default_and_explicit_plotly_behavior_are_unchanged():
     assert isinstance(default, go.Figure)
     assert pio.to_json(default) == pio.to_json(explicit)
 
-    performance_data = prepare_performance_data(
-        probs=probs,
-        reals=REALS_EQUAL,
-        by=0.25,
-    )
+    performance_data = prepare_performance_data(probs=probs, reals=REALS_EQUAL, by=0.25)
     default_plot = plot_precision_recall_curve(performance_data)
     explicit_plot = plot_precision_recall_curve(performance_data, renderer="plotly")
     assert pio.to_json(default_plot) == pio.to_json(explicit_plot)
@@ -275,13 +267,7 @@ def test_time_dependent_precision_recall_api_does_not_gain_renderer_selection():
 
 
 def test_vendored_v050_contains_static_precision_recall_contract_and_export():
-    vendor = (
-        Path(__file__).parents[1]
-        / "src"
-        / "rtichoke"
-        / "_vendor"
-        / "rtichoke_viz"
-    )
+    vendor = Path(__file__).parents[1] / "src" / "rtichoke" / "_vendor" / "rtichoke_viz"
     bundle = (vendor / "rtichoke-viz.js").read_text(encoding="utf-8")
     schema = (vendor / "rtichoke-viz-v2.schema.json").read_text(encoding="utf-8")
 
@@ -319,9 +305,7 @@ def _serve(directory: Path) -> Iterator[str]:
         server.server_close()
 
 
-def test_public_browser_chart_executes_to_svg_when_chrome_is_available(
-    tmp_path: Path,
-):
+def test_public_browser_chart_executes_to_svg_when_chrome_is_available(tmp_path: Path):
     chart = create_precision_recall_curve(
         {"Model A": PROBS_A},
         REALS_EQUAL,

--- a/tests/test_precision_recall_v2.py
+++ b/tests/test_precision_recall_v2.py
@@ -66,9 +66,17 @@ def test_one_model_spec_is_pure_pass_through_with_deterministic_ids():
         }
     ]
 
-    expected_rows = performance_data.select(
+    source_rows = performance_data.select(
         "chosen_cutoff", "sensitivity", "ppv"
     ).to_dicts()
+    assert any(np.isnan(row["ppv"]) for row in source_rows)
+    expected_rows = [
+        row
+        for row in source_rows
+        if np.isfinite(row["chosen_cutoff"])
+        and np.isfinite(row["sensitivity"])
+        and np.isfinite(row["ppv"])
+    ]
     assert spec["data"] == [
         {
             "seriesId": "series-1",


### PR DESCRIPTION
## Summary
- add canonical static Precision-Recall v2 adaptation over existing calculated performance rows
- reuse `_EvaluationMetadata`, deterministic evaluation/series IDs, and population-owned prevalence references
- expose opt-in `browser` / `rtichoke_viz` rendering for static `create_precision_recall_curve()` and `plot_precision_recall_curve()` via the existing `RtichokeBrowserChart`
- preserve default Plotly behavior and leave `create_precision_recall_curve_times()` unchanged
- add focused canonical, renderer, immutable-vendor, compatibility, and real-browser SVG coverage

## Scope
No `rtichoke_viz` vendoring change, Decision Curve work, ReportSpec/summary-report change, time-dependent PR browser adoption, or statistical recalculation.